### PR TITLE
fix: remove react-transition-group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/node": "^22.0.0",
         "@types/react": "^18.3.0",
         "@types/react-dom": "^18.3.0",
-        "@types/react-transition-group": "^4.4.12",
         "@typescript-eslint/eslint-plugin": "^8.56.1",
         "@typescript-eslint/parser": "^8.56.1",
         "@vitejs/plugin-react": "^5.1.4",
@@ -39,8 +38,7 @@
       },
       "peerDependencies": {
         "react": ">=16",
-        "react-dom": ">=16",
-        "react-transition-group": "^4.4.5"
+        "react-dom": ">=16"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -295,16 +293,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2137,16 +2125,6 @@
         "@types/react": "^18.0.0"
       }
     },
-    "node_modules/@types/react-transition-group": {
-      "version": "4.4.12",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -3223,6 +3201,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-view-buffer": {
@@ -3411,17 +3390,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -5265,6 +5233,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5502,6 +5471,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5731,6 +5701,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6209,6 +6180,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -6220,6 +6192,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -6253,6 +6226,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -6265,6 +6239,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -6289,23 +6264,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
-      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.5.5",
-        "dom-helpers": "^5.0.1",
-        "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=16.6.0",
-        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -6588,6 +6546,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "@types/node": "^22.0.0",
     "@types/react": "^18.3.0",
     "@types/react-dom": "^18.3.0",
-    "@types/react-transition-group": "^4.4.12",
     "@typescript-eslint/eslint-plugin": "^8.56.1",
     "@typescript-eslint/parser": "^8.56.1",
     "@vitejs/plugin-react": "^5.1.4",
@@ -100,7 +99,6 @@
   },
   "peerDependencies": {
     "react": ">=16",
-    "react-dom": ">=16",
-    "react-transition-group": "^4.4.5"
+    "react-dom": ">=16"
   }
 }

--- a/src/App.css
+++ b/src/App.css
@@ -149,52 +149,18 @@
   background-color: var(--dark-close-icon-hover);
 }
 
-.fade-enter,
-.fade-appear {
-  opacity: 0;
-  transform: translateY(100%);
-}
-.fade-enter-active,
-.fade-appear-active {
+.fade-enter-active {
   opacity: 1;
   transform: translateY(0%);
   transition:
     opacity 260ms,
     transform 260ms var(--enter-animation);
-  -o-transition:
-    opacity 260ms,
-    transform 260ms var(--enter-animation);
-  -moz-transition:
-    opacity 260ms,
-    transform 260ms var(--enter-animation);
-  -webkit-transition:
-    opacity 260ms,
-    transform 260ms var(--enter-animation);
-}
-.fade-enter-done {
-  opacity: 1;
-}
-.fade-exit {
-  opacity: 1;
-  transform: translateY(0%);
-}
-.fade-exit-active {
-  opacity: 0.3;
-  transform: translateY(200%);
-  transition:
-    opacity 260ms,
-    transform 260ms var(--exit-animation);
-  -o-transition:
-    opacity 260ms,
-    transform 260ms var(--exit-animation);
-  -moz-transition:
-    opacity 260ms,
-    transform 260ms var(--exit-animation);
-  -webkit-transition:
-    opacity 260ms,
-    transform 260ms var(--exit-animation);
 }
 
-.fade-exit-done {
+.fade-exit-active {
   opacity: 0;
+  transform: translateY(100%);
+  transition:
+    opacity 260ms,
+    transform 260ms var(--exit-animation);
 }

--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -1,5 +1,4 @@
-import React, { forwardRef, useEffect } from 'react'
-import { CSSTransition, SwitchTransition } from 'react-transition-group'
+import React, { forwardRef, useEffect, useRef, useState } from 'react'
 import './App.css'
 import { useFirstRender } from './hooks'
 import { closeIcon, offlineIcon, onlineIcon } from './icons'
@@ -32,6 +31,8 @@ interface OnlineStatusNotificationProps {
   statusText?: StatusText
 }
 
+type Phase = 'hidden' | 'entering' | 'visible' | 'exiting'
+
 const DefaultOnlineText = 'Your internet connection was restored.'
 const DefaultOfflineText = 'You are currently offline.'
 
@@ -61,8 +62,6 @@ const OnlineStatusNotificationComponent = forwardRef<
   HTMLDivElement,
   OnlineStatusNotificationProps
 >((props, ref): JSX.Element => {
-  const [isOpen, setIsOpen] = React.useState(false)
-
   const {
     darkMode = false,
     destoryOnClose = true,
@@ -73,40 +72,69 @@ const OnlineStatusNotificationComponent = forwardRef<
     statusText,
   } = props
 
-  const [hovering, setHovering] = React.useState(false)
+  const [phase, setPhase] = useState<Phase>('hidden')
+  const [hovering, setHovering] = useState(false)
+  const [displayedOnline, setDisplayedOnline] = useState(isOnline)
 
-  const onlineRef = React.useRef<HTMLDivElement>(null)
-
-  const offlineRef = React.useRef<HTMLDivElement>(null)
-
-  const timeoutRef = React.useRef(null)
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>(null)
+  const pendingReopenRef = useRef(false)
+  const phaseRef = useRef<Phase>(phase)
+  phaseRef.current = phase
 
   const { isFirstRender } = useFirstRender()
 
-  const nodeRef = isOnline ? onlineRef : offlineRef
+  const isVisible = phase === 'visible'
 
-  const toggleVisibility = (flag: boolean) => setIsOpen(flag)
+  const enterNotification = React.useCallback(() => {
+    pendingReopenRef.current = false
+    setPhase('entering')
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => setPhase('visible'))
+    })
+  }, [])
 
   React.useImperativeHandle(ref, (): any => ({
-    openStatus: () => toggleVisibility(true),
+    openStatus: () => enterNotification(),
   }))
 
+  // When isOnline changes, trigger the notification
   useEffect(() => {
-    if (!isFirstRender) return toggleVisibility(true)
-  }, [isOnline, isFirstRender])
+    if (isFirstRender) return
 
+    setDisplayedOnline(isOnline)
+
+    if (phaseRef.current === 'visible' || phaseRef.current === 'entering') {
+      pendingReopenRef.current = true
+      setPhase('exiting')
+    } else {
+      enterNotification()
+    }
+  }, [isOnline, isFirstRender, enterNotification])
+
+  const handleTransitionEnd = (e: React.TransitionEvent) => {
+    if (e.target !== e.currentTarget) return
+
+    if (phaseRef.current === 'exiting') {
+      if (pendingReopenRef.current) {
+        enterNotification()
+      } else {
+        setPhase('hidden')
+      }
+    }
+  }
+
+  // Auto-hide after duration
   useEffect(() => {
-    const cleanupFn = () =>
-      timeoutRef.current && clearTimeout(timeoutRef.current)
-
-    if (!hovering && duration > 0 && isOpen) {
+    if (!hovering && duration > 0 && isVisible) {
       timeoutRef.current = setTimeout(() => {
-        toggleVisibility(false)
+        setPhase('exiting')
       }, duration)
 
-      return cleanupFn
+      return () => {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current)
+      }
     }
-  }, [duration, hovering, isOpen, isOnline])
+  }, [duration, hovering, isVisible, isOnline])
 
   const handleRefreshButtonClick = () => {
     if (eventsCallback?.onRefreshClick) {
@@ -124,67 +152,46 @@ const OnlineStatusNotificationComponent = forwardRef<
     if (eventsCallback?.onCloseClick) {
       eventsCallback.onCloseClick()
     }
-    toggleVisibility(false)
+    setPhase('exiting')
   }
 
   if (isFirstRender && isOnline) return null
+  if (destoryOnClose && phase === 'hidden') return null
+
+  const animationClass =
+    phase === 'visible' ? 'fade-enter-active' : 'fade-exit-active'
 
   return (
-    <CSSTransition
-      in={isOpen}
-      timeout={260}
-      nodeRef={nodeRef}
-      appear={true}
-      classNames={'fade'}
-      unmountOnExit={destoryOnClose}
+    <div
+      className={classNames(
+        'statusNotification',
+        darkMode ? 'darkColor' : 'defaultColor',
+        position,
+        animationClass,
+      )}
+      onTransitionEnd={handleTransitionEnd}
+      onMouseEnter={() => setHovering(true)}
+      onMouseLeave={() => setHovering(false)}
     >
-      <SwitchTransition mode={'out-in'}>
-        <CSSTransition
-          key={isOnline ? 'Online' : 'Offline'}
-          nodeRef={nodeRef}
-          addEndListener={(done: () => void) => {
-            nodeRef.current?.addEventListener('transitionend', done, false)
-          }}
-          classNames="fade"
-        >
-          <div
-            className={classNames(
-              'statusNotification',
-              darkMode ? 'darkColor' : 'defaultColor',
-              position,
-            )}
-            ref={nodeRef}
-            onMouseEnter={() => {
-              setHovering(true)
-            }}
-            onMouseLeave={() => {
-              setHovering(false)
-            }}
-          >
-            <div className="statusNotificationIcon">
-              {isOnline ? onlineIcon : offlineIcon}
-            </div>
-            <div>{getStatusText(isOnline, statusText)}</div>
-            {/* refresh link */}
-            {!isOnline && (
-              <div className="statusNotificationRefresh">
-                <span onClick={handleRefreshButtonClick}>Refresh</span>
-              </div>
-            )}
-            {/* close icon */}
-            <div
-              className={classNames(
-                'statusNotificationCloseIcon',
-                darkMode ? 'darkColor' : 'defaultColor',
-              )}
-              onClick={handleCloseButtonClick}
-            >
-              {closeIcon}
-            </div>
-          </div>
-        </CSSTransition>
-      </SwitchTransition>
-    </CSSTransition>
+      <div className="statusNotificationIcon">
+        {displayedOnline ? onlineIcon : offlineIcon}
+      </div>
+      <div>{getStatusText(displayedOnline, statusText)}</div>
+      {!displayedOnline && (
+        <div className="statusNotificationRefresh">
+          <span onClick={handleRefreshButtonClick}>Refresh</span>
+        </div>
+      )}
+      <div
+        className={classNames(
+          'statusNotificationCloseIcon',
+          darkMode ? 'darkColor' : 'defaultColor',
+        )}
+        onClick={handleCloseButtonClick}
+      >
+        {closeIcon}
+      </div>
+    </div>
   )
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,7 +36,6 @@ export default defineConfig({
         globals: {
           react: 'React',
           'react-dom': 'ReactDOM',
-          'react-transition-group': 'ReactTransitionGroup',
         },
       },
     },


### PR DESCRIPTION
this PR removes react-transition-group as a peer dependency and replaces it with pure CSS transitions using onTransitionEnd, fixing the broken Transition2 prop type error with React 18.