### PR TITLE
feat: automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: [Checks]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Tag & Publish
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for version change
+        id: version
+        run: |
+          CURRENT=$(node -p "require('./package.json').version")
+          PREVIOUS=$(git show HEAD~1:package.json 2>/dev/null | node -p "JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version" 2>/dev/null || echo "")
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          if [ "$CURRENT" != "$PREVIOUS" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check tag doesn't already exist
+        if: steps.version.outputs.changed == 'true'
+        id: tag-check
+        run: |
+          TAG="v${{ steps.version.outputs.current }}"
+          if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "$TAG"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create git tag
+        if: steps.version.outputs.changed == 'true' && steps.tag-check.outputs.exists == 'false'
+        run: |
+          TAG="v${{ steps.version.outputs.current }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - uses: actions/setup-node@v4
+        if: steps.version.outputs.changed == 'true' && steps.tag-check.outputs.exists == 'false'
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install & Build
+        if: steps.version.outputs.changed == 'true' && steps.tag-check.outputs.exists == 'false'
+        run: |
+          npm ci
+          npm run build
+
+      - name: Publish to npm
+        if: steps.version.outputs.changed == 'true' && steps.tag-check.outputs.exists == 'false'
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: steps.version.outputs.changed == 'true' && steps.tag-check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="v${{ steps.version.outputs.current }}"
+          gh release create "$TAG" --generate-notes


### PR DESCRIPTION
## Summary

Adds a release workflow that automates the tag + npm publish flow we've been doing manually.

### How it works

1. **Triggers after** the Checks workflow passes on `main` (not on PRs)
2. **Detects version bumps** by comparing `package.json` version against the previous commit
3. If version changed and tag doesn't already exist:
   - Creates and pushes a git tag (`v{version}`)
   - Builds and publishes to npm
   - Creates a GitHub Release with auto-generated notes

### Flow

```
push to main → Checks (lint, type-check, test, build)
                  ↓ (on success)
               Release (tag → npm publish → GitHub Release)
                  ↓ (always on main push)
               Deploy demo site
```

### Setup required

Add `NPM_TOKEN` as a repository secret (Settings → Secrets → Actions).

## Test plan

- [ ] Add `NPM_TOKEN` secret to repo
- [ ] Bump version and push to main — verify tag, npm publish, and GH release are created
- [ ] Push without version change — verify release is skipped