### PR TITLE
fix: remove duplicate polling and add transition fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-nsn",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-nsn",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nsn",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": false,
   "description": "React hook and notification component for detecting online/offline network status. Zero dependencies, SSR-safe, accessible.",
   "license": "MIT",

--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from 'react'
 import './App.css'
-import { useFirstRender } from './hooks'
 import { closeIcon, offlineIcon, onlineIcon } from './icons'
 
 type StatusText = {
@@ -41,6 +40,7 @@ type Phase = 'hidden' | 'entering' | 'visible' | 'exiting'
 
 const DefaultOnlineText = 'Your internet connection was restored.'
 const DefaultOfflineText = 'You are currently offline.'
+const TRANSITION_FALLBACK_MS = 400
 
 /**
  * The notification component will pop up when the network status becomes offline and will popup once again when it goes back online
@@ -84,10 +84,9 @@ const OnlineStatusNotificationComponent = forwardRef<
 
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingOnlineRef = useRef<boolean | null>(null)
+  const isFirstChangeRef = useRef(true)
   const phaseRef = useRef<Phase>(phase)
   phaseRef.current = phase
-
-  const { isFirstRender } = useFirstRender()
 
   const isVisible = phase === 'visible'
 
@@ -106,7 +105,10 @@ const OnlineStatusNotificationComponent = forwardRef<
 
   // When isOnline changes, trigger the notification
   useEffect(() => {
-    if (isFirstRender) return
+    if (isFirstChangeRef.current) {
+      isFirstChangeRef.current = false
+      if (isOnline) return
+    }
 
     if (phaseRef.current === 'visible' || phaseRef.current === 'entering') {
       // Already showing — exit first, swap content after exit completes
@@ -115,19 +117,29 @@ const OnlineStatusNotificationComponent = forwardRef<
     } else {
       enterNotification(isOnline)
     }
-  }, [isOnline, isFirstRender, enterNotification])
+  }, [isOnline, enterNotification])
+
+  const completeExit = useCallback(() => {
+    if (phaseRef.current !== 'exiting') return
+    if (pendingOnlineRef.current !== null) {
+      enterNotification(pendingOnlineRef.current)
+    } else {
+      setPhase('hidden')
+    }
+  }, [enterNotification])
 
   const handleTransitionEnd = (e: React.TransitionEvent) => {
     if (e.target !== e.currentTarget) return
-
-    if (phaseRef.current === 'exiting') {
-      if (pendingOnlineRef.current !== null) {
-        enterNotification(pendingOnlineRef.current)
-      } else {
-        setPhase('hidden')
-      }
-    }
+    completeExit()
   }
+
+  // Fallback in case transitionend never fires
+  useEffect(() => {
+    if (phase === 'exiting') {
+      const id = setTimeout(completeExit, TRANSITION_FALLBACK_MS)
+      return () => clearTimeout(id)
+    }
+  }, [phase, completeExit])
 
   // Auto-hide after duration
   useEffect(() => {
@@ -161,7 +173,6 @@ const OnlineStatusNotificationComponent = forwardRef<
     setPhase('exiting')
   }
 
-  if (isFirstRender && isOnline) return null
   if (destoryOnClose && phase === 'hidden') return null
 
   const phaseClass =

--- a/src/__tests__/OnlineStatusNotification.test.tsx
+++ b/src/__tests__/OnlineStatusNotification.test.tsx
@@ -1,33 +1,21 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import OnlineStatusNotification from '../OnlineStatusNotification'
-
-vi.mock('../hooks', () => ({
-  useFirstRender: () => ({ isFirstRender: false }),
-}))
-
-beforeEach(() => {
-  vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response())
-})
 
 describe('OnlineStatusNotification', () => {
   describe('rendering', () => {
-    it('renders the notification when offline', () => {
+    it('renders nothing on first render when online', () => {
+      const { container } = render(
+        <OnlineStatusNotification isOnline={true} />,
+      )
+      expect(container.firstChild).toBeNull()
+    })
+
+    it('renders the notification immediately when starting offline', () => {
       render(<OnlineStatusNotification isOnline={false} />)
       expect(screen.getByRole('status')).toBeInTheDocument()
-    })
-
-    it('displays default offline text', () => {
-      render(<OnlineStatusNotification isOnline={false} />)
       expect(
         screen.getByText('You are currently offline.'),
-      ).toBeInTheDocument()
-    })
-
-    it('displays default online text', () => {
-      render(<OnlineStatusNotification isOnline={true} />)
-      expect(
-        screen.getByText('Your internet connection was restored.'),
       ).toBeInTheDocument()
     })
 
@@ -41,20 +29,23 @@ describe('OnlineStatusNotification', () => {
       expect(screen.getByText('No connection!')).toBeInTheDocument()
     })
 
-})
+    it('shows notification when going offline after starting online', () => {
+      const { rerender } = render(
+        <OnlineStatusNotification isOnline={true} />,
+      )
+      rerender(<OnlineStatusNotification isOnline={false} />)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+      expect(
+        screen.getByText('You are currently offline.'),
+      ).toBeInTheDocument()
+    })
+  })
 
   describe('accessibility', () => {
-    it('has role="status" on the container', () => {
+    it('has role="status" and aria-live="polite" on the container', () => {
       render(<OnlineStatusNotification isOnline={false} />)
-      expect(screen.getByRole('status')).toBeInTheDocument()
-    })
-
-    it('has aria-live="polite" on the container', () => {
-      render(<OnlineStatusNotification isOnline={false} />)
-      expect(screen.getByRole('status')).toHaveAttribute(
-        'aria-live',
-        'polite',
-      )
+      const status = screen.getByRole('status')
+      expect(status).toHaveAttribute('aria-live', 'polite')
     })
 
     it('renders the refresh control as a button', () => {
@@ -126,14 +117,10 @@ describe('OnlineStatusNotification', () => {
   })
 
   describe('destroyOnClose', () => {
-    it('removes from DOM when hidden and destoryOnClose is true', () => {
+    it('renders notification in DOM when destoryOnClose is true and visible', () => {
       const { container } = render(
-        <OnlineStatusNotification
-          isOnline={false}
-          destoryOnClose={true}
-        />,
+        <OnlineStatusNotification isOnline={false} destoryOnClose={true} />,
       )
-      // The notification is showing (entering/visible phase)
       expect(container.querySelector('.statusNotification')).toBeTruthy()
     })
   })

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useReducer, useRef, useState } from 'react'
+import { useCallback, useEffect, useReducer, useRef } from 'react'
 import { DEFAULT_POLLING_URL, timeSince } from './utils'
 
 const isWindowDocumentAvailable = typeof window !== 'undefined'
@@ -179,25 +179,7 @@ export function useInterval(
   }, [delay])
 }
 
-/**
- *
- * @returns flag that indicates if its the first render for the component
- *
- * @internal
- *
- */
-function useFirstRender(): { isFirstRender: boolean } {
-  const [firstRender, setFirstRender] = useState(true)
-
-  const { isOffline } = useOnlineStatus()
-  useEffect(() => {
-    if (firstRender && isOffline) setFirstRender(false)
-  }, [isOffline])
-
-  return { isFirstRender: firstRender }
-}
-
-export { useFirstRender, useOnlineStatus }
+export { useOnlineStatus }
 
 type Megabit = number
 type Millisecond = number


### PR DESCRIPTION
## Summary

- **Remove `useFirstRender` duplicate polling** — The old hook created a second `useOnlineStatus()` instance with its own polling interval and event listeners, doubling network requests. Replaced with a simple ref that suppresses the mount notification when online but shows it immediately when starting offline.
- **Add `transitionend` fallback timeout** — If CSS transitions are disabled or `--nsn-transition-duration` is overridden to `0`, `transitionend` never fires and the notification gets permanently stuck invisible. Added a 400ms safety timeout that forces the exit to complete.
- Removes the pre-existing `react-hooks/exhaustive-deps` lint warning

## Test plan

- [x] `npm run type-check` — passes
- [x] `npm run lint` — 0 errors, 0 warnings
- [x] `npm test` — 32/32 passing
- [x] `npm run build` — no regressions
- [ ] Manual: starting offline shows notification immediately (no 12s delay)
- [ ] Manual: notification exits correctly with `prefers-reduced-motion`

Bumps to v2.1.1 — will auto-tag and publish via release workflow.