### PR TITLE
feat: improve useOnlineStatus hook API and component props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nsn",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "private": false,
   "description": "React hook and notification component for detecting online/offline network status. Zero dependencies, SSR-safe, accessible.",
   "license": "MIT",

--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -8,12 +8,12 @@ import React, {
 import './App.css'
 import { closeIcon, offlineIcon, onlineIcon } from './icons'
 
-type StatusText = {
+export type StatusText = {
   online?: string
   offline?: string
 }
 
-type Position =
+export type Position =
   | 'topLeft'
   | 'topRight'
   | 'topCenter'
@@ -26,8 +26,10 @@ type EventsCallback = {
   onCloseClick: () => void
 }
 
-interface OnlineStatusNotificationProps {
+export interface OnlineStatusNotificationProps {
   darkMode?: boolean
+  destroyOnClose?: boolean
+  /** @deprecated Use `destroyOnClose` instead */
   destoryOnClose?: boolean
   duration?: number
   eventsCallback?: EventsCallback
@@ -55,7 +57,8 @@ const TRANSITION_FALLBACK_MS = 400
  *
  * ```
  * @param darkMode toggle dark mode on
- * @param destoryOnClose remove notification from dom when it hides
+ * @param destroyOnClose remove notification from dom when it hides
+ * @param destoryOnClose @deprecated use `destroyOnClose` instead
  * @param duration duration of the notification in ms
  * @param eventsCallback object that contains 2 callbacks that are called when refresh button is clicked or close button clicked
  * @param isOnline status of the app when online
@@ -70,13 +73,16 @@ const OnlineStatusNotificationComponent = forwardRef<
 >((props, ref) => {
   const {
     darkMode = false,
-    destoryOnClose = true,
+    destroyOnClose,
+    destoryOnClose,
     duration = 4500,
     eventsCallback,
     isOnline,
     position = 'bottomLeft',
     statusText,
   } = props
+
+  const shouldDestroyOnClose = destroyOnClose ?? destoryOnClose ?? true
 
   const [phase, setPhase] = useState<Phase>('hidden')
   const [hovering, setHovering] = useState(false)
@@ -173,7 +179,7 @@ const OnlineStatusNotificationComponent = forwardRef<
     setPhase('exiting')
   }
 
-  if (destoryOnClose && phase === 'hidden') return null
+  if (shouldDestroyOnClose && phase === 'hidden') return null
 
   const phaseClass =
     phase === 'entering'

--- a/src/__tests__/OnlineStatusNotification.test.tsx
+++ b/src/__tests__/OnlineStatusNotification.test.tsx
@@ -5,18 +5,14 @@ import OnlineStatusNotification from '../OnlineStatusNotification'
 describe('OnlineStatusNotification', () => {
   describe('rendering', () => {
     it('renders nothing on first render when online', () => {
-      const { container } = render(
-        <OnlineStatusNotification isOnline={true} />,
-      )
+      const { container } = render(<OnlineStatusNotification isOnline={true} />)
       expect(container.firstChild).toBeNull()
     })
 
     it('renders the notification immediately when starting offline', () => {
       render(<OnlineStatusNotification isOnline={false} />)
       expect(screen.getByRole('status')).toBeInTheDocument()
-      expect(
-        screen.getByText('You are currently offline.'),
-      ).toBeInTheDocument()
+      expect(screen.getByText('You are currently offline.')).toBeInTheDocument()
     })
 
     it('displays custom status text', () => {
@@ -30,14 +26,10 @@ describe('OnlineStatusNotification', () => {
     })
 
     it('shows notification when going offline after starting online', () => {
-      const { rerender } = render(
-        <OnlineStatusNotification isOnline={true} />,
-      )
+      const { rerender } = render(<OnlineStatusNotification isOnline={true} />)
       rerender(<OnlineStatusNotification isOnline={false} />)
       expect(screen.getByRole('status')).toBeInTheDocument()
-      expect(
-        screen.getByText('You are currently offline.'),
-      ).toBeInTheDocument()
+      expect(screen.getByText('You are currently offline.')).toBeInTheDocument()
     })
   })
 
@@ -93,31 +85,32 @@ describe('OnlineStatusNotification', () => {
 
   describe('dark mode', () => {
     it('applies darkColor class when darkMode is true', () => {
-      render(
-        <OnlineStatusNotification isOnline={false} darkMode={true} />,
-      )
+      render(<OnlineStatusNotification isOnline={false} darkMode={true} />)
       expect(screen.getByRole('status')).toHaveClass('darkColor')
     })
 
     it('applies defaultColor class when darkMode is false', () => {
-      render(
-        <OnlineStatusNotification isOnline={false} darkMode={false} />,
-      )
+      render(<OnlineStatusNotification isOnline={false} darkMode={false} />)
       expect(screen.getByRole('status')).toHaveClass('defaultColor')
     })
   })
 
   describe('position', () => {
     it('applies the specified position class', () => {
-      render(
-        <OnlineStatusNotification isOnline={false} position="topRight" />,
-      )
+      render(<OnlineStatusNotification isOnline={false} position="topRight" />)
       expect(screen.getByRole('status')).toHaveClass('topRight')
     })
   })
 
   describe('destroyOnClose', () => {
-    it('renders notification in DOM when destoryOnClose is true and visible', () => {
+    it('renders notification in DOM when destroyOnClose is true and visible', () => {
+      const { container } = render(
+        <OnlineStatusNotification isOnline={false} destroyOnClose={true} />,
+      )
+      expect(container.querySelector('.statusNotification')).toBeTruthy()
+    })
+
+    it('still supports the deprecated destoryOnClose prop', () => {
       const { container } = render(
         <OnlineStatusNotification isOnline={false} destoryOnClose={true} />,
       )

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -71,6 +71,16 @@ describe('useOnlineStatus', () => {
     expect(result.current.isOnline).toBe(true)
   })
 
+  it('checkNow triggers a fetch call', async () => {
+    const { result } = renderHook(() => useOnlineStatus())
+
+    await act(async () => {
+      await result.current.checkNow()
+    })
+
+    expect(globalThis.fetch).toHaveBeenCalled()
+  })
+
   it('polls at the specified duration', async () => {
     renderHook(() => useOnlineStatus({ pollingDuration: 5000 }))
 
@@ -82,9 +92,74 @@ describe('useOnlineStatus', () => {
     expect(globalThis.fetch).toHaveBeenCalled()
   })
 
-  it('error property is null by default', () => {
-    const { result } = renderHook(() => useOnlineStatus())
-    expect(result.current.error).toBeNull()
+  it('fires onStatusChange when going offline', async () => {
+    const onStatusChange = vi.fn()
+    renderHook(() => useOnlineStatus({ onStatusChange }))
+
+    await act(async () => {
+      window.dispatchEvent(new Event('offline'))
+    })
+
+    expect(onStatusChange).toHaveBeenCalledWith(false)
+  })
+
+  it('fires onStatusChange when coming back online', async () => {
+    const onStatusChange = vi.fn()
+    renderHook(() => useOnlineStatus({ onStatusChange }))
+
+    // Go offline first
+    await act(async () => {
+      window.dispatchEvent(new Event('offline'))
+    })
+
+    onStatusChange.mockClear()
+
+    // Come back online
+    await act(async () => {
+      window.dispatchEvent(new Event('online'))
+    })
+
+    expect(onStatusChange).toHaveBeenCalledWith(true)
+  })
+
+  it('pauses polling when the tab is hidden', async () => {
+    renderHook(() => useOnlineStatus({ pollingDuration: 5000 }))
+
+    // Clear any initial fetch calls
+    vi.mocked(globalThis.fetch).mockClear()
+
+    // Hide the tab
+    Object.defineProperty(document, 'hidden', {
+      value: true,
+      writable: true,
+      configurable: true,
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+    })
+
+    // No polling should have occurred while hidden
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+
+    // Show the tab again
+    Object.defineProperty(document, 'hidden', {
+      value: false,
+      configurable: true,
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    // Polling should resume
+    expect(globalThis.fetch).toHaveBeenCalled()
   })
 })
 

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useReducer, useRef } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
 import { DEFAULT_POLLING_URL, timeSince } from './utils'
 
 const isWindowDocumentAvailable = typeof window !== 'undefined'
@@ -20,6 +27,7 @@ function getConnectionInfo(): NetworkInformation | null {
 type OnlineStatusProps = {
   pollingUrl?: string
   pollingDuration?: number
+  onStatusChange?: (isOnline: boolean) => void
 }
 
 const InitialOnlineStatus = isNavigatorObjectAvailable ? navigator.onLine : true
@@ -71,22 +79,27 @@ function statusReducer(prevState: State, action: ReducerActions): State {
  * ```
  * @param pollingUrl your custom polling url
  * @param pollingDuration your custom polling duration in ms
+ * @param onStatusChange callback fired when the online status changes (skips initial render)
  * @returns Current network status, connection info,
- * and time since online/offline,
- * attributes to be passed to notification component if used
+ * time since online/offline,
+ * attributes to be passed to notification component if used,
+ * and checkNow to manually trigger a connectivity check
  */
+
+type OnlineStatusResult = {
+  attributes: { isOnline: boolean }
+  checkNow: () => Promise<void>
+  connectionInfo: NetworkInformation | null
+  isOffline: boolean
+  isOnline: boolean
+  time: { since: Date; difference: string }
+}
 
 function useOnlineStatus({
   pollingUrl = DEFAULT_POLLING_URL,
   pollingDuration = 12000,
-}: OnlineStatusProps = {}): {
-  attributes: { isOnline: boolean }
-  connectionInfo: NetworkInformation | null
-  error: Error | null
-  isOffline: boolean
-  isOnline: boolean
-  time: { since: Date; difference: string }
-} {
+  onStatusChange,
+}: OnlineStatusProps = {}): OnlineStatusResult {
   const [statusState, dispatch] = useReducer(statusReducer, {
     online: InitialOnlineStatus,
     time: {
@@ -95,7 +108,7 @@ function useOnlineStatus({
     },
   })
 
-  const connectionInfo = getConnectionInfo()
+  const connectionInfo = useMemo(() => getConnectionInfo(), [])
 
   const _onlineStatusFn = useCallback(async () => {
     await fetch(pollingUrl, { mode: 'no-cors' })
@@ -113,7 +126,20 @@ function useOnlineStatus({
       })
   }, [pollingUrl])
 
-  useInterval(_onlineStatusFn, pollingDuration)
+  const [tabVisible, setTabVisible] = useState(
+    isWindowDocumentAvailable ? !document.hidden : true,
+  )
+
+  useEffect(() => {
+    if (isWindowDocumentAvailable) {
+      const onVisibilityChange = () => setTabVisible(!document.hidden)
+      document.addEventListener('visibilitychange', onVisibilityChange)
+      return () =>
+        document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [])
+
+  useInterval(_onlineStatusFn, tabVisible ? pollingDuration : null)
 
   const handleOnlineStatus = useCallback(
     async ({ type }: Event) => {
@@ -139,10 +165,23 @@ function useOnlineStatus({
     }
   }, [handleOnlineStatus])
 
+  // Fire onStatusChange callback when status changes (skip initial render)
+  const onStatusChangeRef = useRef(onStatusChange)
+  onStatusChangeRef.current = onStatusChange
+  const isInitialRenderRef = useRef(true)
+
+  useEffect(() => {
+    if (isInitialRenderRef.current) {
+      isInitialRenderRef.current = false
+      return
+    }
+    onStatusChangeRef.current?.(statusState.online)
+  }, [statusState.online])
+
   return {
     attributes: { isOnline: statusState.online },
+    checkNow: _onlineStatusFn,
     connectionInfo,
-    error: null,
     isOffline: !statusState.online,
     isOnline: statusState.online,
     time: { since: statusState.time.since, difference: statusState.time.diff },
@@ -180,6 +219,7 @@ export function useInterval(
 }
 
 export { useOnlineStatus }
+export type { OnlineStatusResult }
 
 type Megabit = number
 type Millisecond = number
@@ -194,7 +234,7 @@ type ConnectionType =
   | 'unknown'
   | 'wifi'
   | 'wimax'
-interface NetworkInformation extends EventTarget {
+export interface NetworkInformation extends EventTarget {
   readonly type?: ConnectionType
   readonly effectiveType?: EffectiveConnectionType
   readonly downlinkMax?: Megabit

--- a/src/nsn.ts
+++ b/src/nsn.ts
@@ -1,2 +1,8 @@
 export { useOnlineStatus } from './hooks'
+export type { NetworkInformation, OnlineStatusResult } from './hooks'
 export { default as OnlineStatusNotification } from './OnlineStatusNotification'
+export type {
+  OnlineStatusNotificationProps,
+  Position,
+  StatusText,
+} from './OnlineStatusNotification'


### PR DESCRIPTION
## Summary

- **Fix `destroyOnClose` typo** — adds correct prop alongside deprecated `destoryOnClose` (non-breaking)
- **Remove dead `error` field** — always returned `null`, removed from return type
- **Memoize `connectionInfo`** — wrapped in `useMemo` to avoid recalculating every render
- **Add `checkNow()`** — exposes the internal polling function for manual connectivity checks
- **Add `onStatusChange` callback** — fires when online status changes, skips initial render
- **Pause polling when tab is hidden** — uses Page Visibility API to stop unnecessary network requests
- **Export consumer types** — `OnlineStatusNotificationProps`, `Position`, `StatusText`, `NetworkInformation`, `OnlineStatusResult`
- **Bump version to 2.2.0**

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 36/36 tests pass (added tests for `checkNow`, `onStatusChange`, `destroyOnClose` backward compat, visibility polling pause)
- [x] `npm run build` succeeds