### PR TITLE
fix: hook correctness fixes and component API cleanup

### DIFF
--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -21,9 +21,9 @@ export type Position =
   | 'bottomRight'
   | 'bottomCenter'
 
-type EventsCallback = {
-  onRefreshClick: () => void
-  onCloseClick: () => void
+export type EventsCallback = {
+  onRefreshClick?: () => void
+  onCloseClick?: () => void
 }
 
 export interface OnlineStatusNotificationProps {
@@ -107,6 +107,7 @@ const OnlineStatusNotificationComponent = forwardRef<
 
   React.useImperativeHandle(ref, (): any => ({
     openStatus: () => enterNotification(isOnline),
+    dismiss: () => setPhase('exiting'),
   }))
 
   // When isOnline changes, trigger the notification

--- a/src/__tests__/OnlineStatusNotification.test.tsx
+++ b/src/__tests__/OnlineStatusNotification.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import OnlineStatusNotification from '../OnlineStatusNotification'
 
@@ -56,12 +57,25 @@ describe('OnlineStatusNotification', () => {
   })
 
   describe('click handlers', () => {
+    it('works with only onCloseClick in eventsCallback', () => {
+      const onCloseClick = vi.fn()
+      render(
+        <OnlineStatusNotification
+          isOnline={false}
+          eventsCallback={{ onCloseClick }}
+        />,
+      )
+
+      fireEvent.click(screen.getByLabelText('Close notification'))
+      expect(onCloseClick).toHaveBeenCalledTimes(1)
+    })
+
     it('calls onRefreshClick callback when refresh is clicked', () => {
       const onRefreshClick = vi.fn()
       render(
         <OnlineStatusNotification
           isOnline={false}
-          eventsCallback={{ onRefreshClick, onCloseClick: vi.fn() }}
+          eventsCallback={{ onRefreshClick }}
         />,
       )
 
@@ -74,12 +88,27 @@ describe('OnlineStatusNotification', () => {
       render(
         <OnlineStatusNotification
           isOnline={false}
-          eventsCallback={{ onRefreshClick: vi.fn(), onCloseClick }}
+          eventsCallback={{ onCloseClick }}
         />,
       )
 
       fireEvent.click(screen.getByLabelText('Close notification'))
       expect(onCloseClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('imperative handle', () => {
+    it('dismiss() triggers the exiting phase', () => {
+      const ref = React.createRef<any>()
+      render(<OnlineStatusNotification ref={ref} isOnline={false} />)
+
+      expect(screen.getByRole('status')).toBeInTheDocument()
+
+      act(() => {
+        ref.current.dismiss()
+      })
+
+      expect(screen.getByRole('status')).toHaveClass('fade-exit-active')
     })
   })
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -154,12 +154,15 @@ describe('useOnlineStatus', () => {
       document.dispatchEvent(new Event('visibilitychange'))
     })
 
+    // Should check immediately on tab return
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+
     await act(async () => {
       vi.advanceTimersByTime(5000)
     })
 
-    // Polling should resume
-    expect(globalThis.fetch).toHaveBeenCalled()
+    // And polling should resume after the interval
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -64,7 +64,7 @@ function statusReducer(prevState: State, action: ReducerActions): State {
       }
     }
     default:
-      return { ...prevState }
+      return prevState
   }
 }
 
@@ -111,19 +111,12 @@ function useOnlineStatus({
   const connectionInfo = useMemo(() => getConnectionInfo(), [])
 
   const _onlineStatusFn = useCallback(async () => {
-    await fetch(pollingUrl, { mode: 'no-cors' })
-      .then(
-        (response) =>
-          response &&
-          dispatch({
-            type: 'online',
-          }),
-      )
-      .catch(() => {
-        return dispatch({
-          type: 'offline',
-        })
-      })
+    try {
+      await fetch(pollingUrl, { mode: 'no-cors' })
+      dispatch({ type: 'online' })
+    } catch {
+      dispatch({ type: 'offline' })
+    }
   }, [pollingUrl])
 
   const [tabVisible, setTabVisible] = useState(
@@ -132,17 +125,21 @@ function useOnlineStatus({
 
   useEffect(() => {
     if (isWindowDocumentAvailable) {
-      const onVisibilityChange = () => setTabVisible(!document.hidden)
+      const onVisibilityChange = () => {
+        const visible = !document.hidden
+        setTabVisible(visible)
+        if (visible) _onlineStatusFn()
+      }
       document.addEventListener('visibilitychange', onVisibilityChange)
       return () =>
         document.removeEventListener('visibilitychange', onVisibilityChange)
     }
-  }, [])
+  }, [_onlineStatusFn])
 
   useInterval(_onlineStatusFn, tabVisible ? pollingDuration : null)
 
   const handleOnlineStatus = useCallback(
-    async ({ type }: Event) => {
+    ({ type }: Event) => {
       if (type === 'online') {
         _onlineStatusFn()
       } else {


### PR DESCRIPTION
## Summary

**Bug fixes:**
- Immediately check connectivity when the tab becomes visible again (was waiting up to 12s)
- Return `prevState` in reducer default case instead of spreading a new object (avoids unnecessary re-renders)
- Remove misleading `async` from `handleOnlineStatus` (never awaited anything)

**Code cleanup:**
- Rewrite `_onlineStatusFn` with `try`/`catch` instead of mixed `await`/`.then()`/`.catch()`
- Remove dead `response &&` guard (always truthy with `mode: 'no-cors'`)

**API improvements:**
- Make `EventsCallback` fields optional — consumers no longer need to pass no-op handlers
- Add `dismiss()` to the imperative handle for programmatic notification dismissal
- Export `EventsCallback` type for consumers

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 38/38 tests pass (updated visibility test, added partial eventsCallback test, added dismiss test)
- [x] `npm run build` succeeds