### PR TITLE
feat: typed ref, backoff, pollingFn, className/style

### DIFF
--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -26,7 +26,13 @@ export type EventsCallback = {
   onCloseClick?: () => void
 }
 
+export interface OnlineStatusNotificationRef {
+  openStatus: () => void
+  dismiss: () => void
+}
+
 export interface OnlineStatusNotificationProps {
+  className?: string
   darkMode?: boolean
   destroyOnClose?: boolean
   /** @deprecated Use `destroyOnClose` instead */
@@ -36,6 +42,7 @@ export interface OnlineStatusNotificationProps {
   isOnline: boolean
   position?: Position
   statusText?: StatusText
+  style?: React.CSSProperties
 }
 
 type Phase = 'hidden' | 'entering' | 'visible' | 'exiting'
@@ -56,22 +63,25 @@ const TRANSITION_FALLBACK_MS = 400
  * }
  *
  * ```
+ * @param className additional CSS class name(s) to apply to the notification container
  * @param darkMode toggle dark mode on
  * @param destroyOnClose remove notification from dom when it hides
  * @param destoryOnClose @deprecated use `destroyOnClose` instead
  * @param duration duration of the notification in ms
- * @param eventsCallback object that contains 2 callbacks that are called when refresh button is clicked or close button clicked
+ * @param eventsCallback object that contains callbacks for refresh and close button clicks
  * @param isOnline status of the app when online
  * @param position customize notification component position
- * @param statusText customize online/offline status objects.
+ * @param statusText customize online/offline status objects
+ * @param style inline styles to apply to the notification container
  * @returns JSX Element
  *
  */
 const OnlineStatusNotificationComponent = forwardRef<
-  HTMLDivElement,
+  OnlineStatusNotificationRef,
   OnlineStatusNotificationProps
 >((props, ref) => {
   const {
+    className: userClassName,
     darkMode = false,
     destroyOnClose,
     destoryOnClose,
@@ -80,6 +90,7 @@ const OnlineStatusNotificationComponent = forwardRef<
     isOnline,
     position = 'bottomLeft',
     statusText,
+    style,
   } = props
 
   const shouldDestroyOnClose = destroyOnClose ?? destoryOnClose ?? true
@@ -105,7 +116,7 @@ const OnlineStatusNotificationComponent = forwardRef<
     })
   }, [])
 
-  React.useImperativeHandle(ref, (): any => ({
+  React.useImperativeHandle(ref, () => ({
     openStatus: () => enterNotification(isOnline),
     dismiss: () => setPhase('exiting'),
   }))
@@ -164,8 +175,8 @@ const OnlineStatusNotificationComponent = forwardRef<
   const handleRefreshButtonClick = () => {
     if (eventsCallback?.onRefreshClick) {
       eventsCallback.onRefreshClick()
-    } else {
-      location.reload()
+    } else if (typeof window !== 'undefined') {
+      window.location.reload()
     }
   }
 
@@ -198,7 +209,9 @@ const OnlineStatusNotificationComponent = forwardRef<
         darkMode ? 'darkColor' : 'defaultColor',
         position,
         phaseClass,
+        userClassName ?? '',
       )}
+      style={style}
       onTransitionEnd={handleTransitionEnd}
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}

--- a/src/__tests__/OnlineStatusNotification.test.tsx
+++ b/src/__tests__/OnlineStatusNotification.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import OnlineStatusNotification from '../OnlineStatusNotification'
+import type { OnlineStatusNotificationRef } from '../OnlineStatusNotification'
 
 describe('OnlineStatusNotification', () => {
   describe('rendering', () => {
@@ -99,13 +100,13 @@ describe('OnlineStatusNotification', () => {
 
   describe('imperative handle', () => {
     it('dismiss() triggers the exiting phase', () => {
-      const ref = React.createRef<any>()
+      const ref = React.createRef<OnlineStatusNotificationRef>()
       render(<OnlineStatusNotification ref={ref} isOnline={false} />)
 
       expect(screen.getByRole('status')).toBeInTheDocument()
 
       act(() => {
-        ref.current.dismiss()
+        ref.current!.dismiss()
       })
 
       expect(screen.getByRole('status')).toHaveClass('fade-exit-active')
@@ -144,6 +145,25 @@ describe('OnlineStatusNotification', () => {
         <OnlineStatusNotification isOnline={false} destoryOnClose={true} />,
       )
       expect(container.querySelector('.statusNotification')).toBeTruthy()
+    })
+  })
+
+  describe('className and style', () => {
+    it('applies custom className to the notification', () => {
+      render(
+        <OnlineStatusNotification isOnline={false} className="my-custom" />,
+      )
+      expect(screen.getByRole('status')).toHaveClass('my-custom')
+    })
+
+    it('applies inline style to the notification', () => {
+      render(
+        <OnlineStatusNotification
+          isOnline={false}
+          style={{ marginTop: '20px' }}
+        />,
+      )
+      expect(screen.getByRole('status')).toHaveStyle({ marginTop: '20px' })
     })
   })
 })

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -122,6 +122,59 @@ describe('useOnlineStatus', () => {
     expect(onStatusChange).toHaveBeenCalledWith(true)
   })
 
+  it('uses custom pollingFn when provided', async () => {
+    const pollingFn = vi.fn().mockResolvedValue(true)
+    renderHook(() => useOnlineStatus({ pollingFn, pollingDuration: 5000 }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(pollingFn).toHaveBeenCalled()
+    // Should NOT use fetch when pollingFn is provided
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('detects offline status via custom pollingFn returning false', async () => {
+    const pollingFn = vi.fn().mockResolvedValue(false)
+    const { result } = renderHook(() =>
+      useOnlineStatus({ pollingFn, pollingDuration: 5000 }),
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(result.current.isOnline).toBe(false)
+  })
+
+  it('backs off polling interval when offline', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'))
+    renderHook(() => useOnlineStatus({ pollingDuration: 1000 }))
+
+    vi.mocked(globalThis.fetch).mockClear()
+
+    // First poll at 1s — should fire
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+
+    // After first failure, delay doubles to 2s
+    // At 2s mark (1s after last poll), should NOT have fired again
+    vi.mocked(globalThis.fetch).mockClear()
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(globalThis.fetch).toHaveBeenCalledTimes(0)
+
+    // At 2s after last poll, should fire
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
   it('pauses polling when the tab is hidden', async () => {
     renderHook(() => useOnlineStatus({ pollingDuration: 5000 }))
 

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -27,6 +27,7 @@ function getConnectionInfo(): NetworkInformation | null {
 type OnlineStatusProps = {
   pollingUrl?: string
   pollingDuration?: number
+  pollingFn?: () => Promise<boolean>
   onStatusChange?: (isOnline: boolean) => void
 }
 
@@ -79,6 +80,7 @@ function statusReducer(prevState: State, action: ReducerActions): State {
  * ```
  * @param pollingUrl your custom polling url
  * @param pollingDuration your custom polling duration in ms
+ * @param pollingFn custom async function for connectivity checks — should return `true` if online, `false` if offline. Overrides `pollingUrl` when provided
  * @param onStatusChange callback fired when the online status changes (skips initial render)
  * @returns Current network status, connection info,
  * time since online/offline,
@@ -98,6 +100,7 @@ type OnlineStatusResult = {
 function useOnlineStatus({
   pollingUrl = DEFAULT_POLLING_URL,
   pollingDuration = 12000,
+  pollingFn,
   onStatusChange,
 }: OnlineStatusProps = {}): OnlineStatusResult {
   const [statusState, dispatch] = useReducer(statusReducer, {
@@ -110,14 +113,31 @@ function useOnlineStatus({
 
   const connectionInfo = useMemo(() => getConnectionInfo(), [])
 
+  const pollingFnRef = useRef(pollingFn)
+  pollingFnRef.current = pollingFn
+
+  const [effectiveDelay, setEffectiveDelay] = useState(pollingDuration)
+
   const _onlineStatusFn = useCallback(async () => {
     try {
-      await fetch(pollingUrl, { mode: 'no-cors' })
-      dispatch({ type: 'online' })
+      if (pollingFnRef.current) {
+        const online = await pollingFnRef.current()
+        dispatch({ type: online ? 'online' : 'offline' })
+        if (online) {
+          setEffectiveDelay(pollingDuration)
+        } else {
+          setEffectiveDelay((prev) => Math.min(prev * 2, 60000))
+        }
+      } else {
+        await fetch(pollingUrl, { mode: 'no-cors' })
+        dispatch({ type: 'online' })
+        setEffectiveDelay(pollingDuration)
+      }
     } catch {
       dispatch({ type: 'offline' })
+      setEffectiveDelay((prev) => Math.min(prev * 2, 60000))
     }
-  }, [pollingUrl])
+  }, [pollingUrl, pollingDuration])
 
   const [tabVisible, setTabVisible] = useState(
     isWindowDocumentAvailable ? !document.hidden : true,
@@ -136,7 +156,7 @@ function useOnlineStatus({
     }
   }, [_onlineStatusFn])
 
-  useInterval(_onlineStatusFn, tabVisible ? pollingDuration : null)
+  useInterval(_onlineStatusFn, tabVisible ? effectiveDelay : null)
 
   const handleOnlineStatus = useCallback(
     ({ type }: Event) => {

--- a/src/nsn.ts
+++ b/src/nsn.ts
@@ -2,7 +2,9 @@ export { useOnlineStatus } from './hooks'
 export type { NetworkInformation, OnlineStatusResult } from './hooks'
 export { default as OnlineStatusNotification } from './OnlineStatusNotification'
 export type {
+  EventsCallback,
   OnlineStatusNotificationProps,
+  OnlineStatusNotificationRef,
   Position,
   StatusText,
 } from './OnlineStatusNotification'


### PR DESCRIPTION
## Summary

**Type safety:**
- Type `useImperativeHandle` with proper `OnlineStatusNotificationRef` interface (removes `any` cast)
- Export `OnlineStatusNotificationRef` and `EventsCallback` types for consumers

**Bug fix:**
- Guard `location.reload()` with `typeof window` check for SSR safety

**New features:**
- **Exponential backoff** when offline — polling interval doubles on each failed check (capped at 60s), resets to base duration on reconnect
- **`pollingFn`** option — custom async function for connectivity checks (should return `true`/`false`), overrides default `fetch` + `no-cors` behavior
- **`className`** and **`style`** props on the notification component for custom styling

## Test plan

- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` — 43/43 tests pass
- [x] `npm run build` succeeds
- [x] Bundle size: 11.7KB gzipped (ESM) — unchanged category