### PR TITLE
feat: mobile and a11y improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,19 @@ Component             |  Example
    - app online network status
    - status time info
    - network information
-   - custom polling
+   - custom polling with exponential backoff
+   - `onStatusChange` callback
+   - `checkNow()` for manual connectivity checks
+   - custom `pollingFn` for your own health-check logic
 2. Notification component `<OnlineStatusNotification/>`
+3. **Headless mode** — use only the hook without the notification UI (~1.4KB gzipped)
 
 
 Table of Contents
 --
 - [Online demo](#online-demo)
 - [How to use](#how-to-use)
+- [Headless mode](#headless-mode)
 - [Documentation](#documentation)
 - [Compatibility](#compatibility)
 - [License](#license)
@@ -44,7 +49,7 @@ npm i react-nsn
 
 ### How to use
 
-add `<OnlineStatusNotification/>` to your app, preferably at root level. 
+add `<OnlineStatusNotification/>` to your app, preferably at root level.
 ```jsx
 import { OnlineStatusNotification, useOnlineStatus } from 'react-nsn'
 
@@ -71,38 +76,61 @@ function App() {
   )
 }
 ```
+
+### Headless mode
+
+If you only need the hook without the notification component, import from `react-nsn/headless` for a smaller bundle (~1.4KB gzipped vs ~10.7KB):
+
+```jsx
+import { useOnlineStatus } from 'react-nsn/headless'
+
+function App() {
+  const { isOnline, checkNow } = useOnlineStatus({
+    onStatusChange: (online) => console.log('Status changed:', online),
+  })
+
+  return <p>{isOnline ? 'Online' : 'Offline'}</p>
+}
+```
   
 ### Documentation
 ```<OnlineStatusNotification/>``` has the following props:
 
 | Name         | Type            | Default   | Description                                                                                                                                                               |
 |------------  |---------------  |---------  |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------  |
+| className       | `string`           |           | additional CSS class name(s) for the notification container |
 | darkMode        | `boolean`          | `false`   | toggle dark mode |
-| destoryOnClose  | `boolean`          | `true`    | remove notification from DOM when it hides |
+| destroyOnClose  | `boolean`          | `true`    | remove notification from DOM when it hides |
 | duration        | `number`           | 4500ms    | duration of the notification when it pops up on screen before hiding back |
-| eventsCallback.onRefreshClick  | `function`         |           | callback function triggered when refresh is clicked during offline status  |
-| eventsCallback.onCloseClick    | `function`         |           | callback function triggered when close button is clicked |
+| eventsCallback.onRefreshClick  | `function`         |           | callback triggered when refresh is clicked during offline status  |
+| eventsCallback.onCloseClick    | `function`         |           | callback triggered when close button is clicked |
 | position        | `string`           | `bottomLeft` | `topLeft` `topRight` `topCenter` `bottomLeft` `bottomRight` `bottomCenter`  |
 | statusText.online   | `string`       | Your internet connection was restored.      | custom online text |
-| statusText.offline  | `string`       | You are currently offline.      | custom offline text
+| statusText.offline  | `string`       | You are currently offline.      | custom offline text |
+| style           | `CSSProperties`    |           | inline styles for the notification container |
+
+The component exposes an imperative handle via `ref` with `openStatus()` and `dismiss()` methods.
 
 ```useOnlineStatus``` hook has the following arguments:
 
 | Name         | Type            | Default   | Description                                                                                                                                                               |
 |------------  |---------------  |---------  |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------  |
-| pollingUrl        | `string`          | `https://www.gstatic.com/generate_204`   | the url used to perform [polling](https://en.wikipedia.org/wiki/Polling_(computer_science)) | 
-| pollingDuration   | `number`          | 12000ms    | fixed delays time between requests |
+| pollingUrl        | `string`          | `https://www.gstatic.com/generate_204`   | url used to perform [polling](https://en.wikipedia.org/wiki/Polling_(computer_science)) |
+| pollingDuration   | `number`          | 12000ms    | base delay between requests (backs off exponentially when offline, capped at 60s) |
+| pollingFn         | `() => Promise<boolean>` |        | custom connectivity check — return `true` if online, `false` if offline. Overrides `pollingUrl` |
+| onStatusChange    | `(isOnline: boolean) => void` |   | callback fired when status changes (skips initial render) |
 
 ```useOnlineStatus``` hook offers the following:
 
-| Name         | Type            | Default   | Description                                                                                                                                                               |
-|------------  |---------------  |---------  |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------  |
-| isOnline        | `boolean`          |    | app online status | 
-| isOffline   | `boolean`          |     | app offline status |
-| time.since    | `Date`          |     | specifies the date of the last status |
-| time.difference    | `string`          |     | the difference in time between latest network status and the current time |
-| connectionInfo    |           |     | The [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API) provides information about the system's connection in terms of general connection type (e.g., 'wifi, 'cellular', etc.). |
-| attributes    | `object`          |     | passed to `<OnlineStatusNotification/>` as prop |
+| Name         | Type            | Description                                                                                                                                                               |
+|------------  |---------------  |-------------------------------------------------------------------------------------------------------------------------------------------------------------------------  |
+| isOnline        | `boolean`          | app online status |
+| isOffline   | `boolean`          | app offline status |
+| checkNow    | `() => Promise<void>` | manually trigger a connectivity check |
+| time.since    | `Date`          | date of the last status change |
+| time.difference    | `string`          | human-readable time since last status change |
+| connectionInfo    | `NetworkInformation \| null` | [Network Information API](https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API) data (connection type, effective type, etc.) |
+| attributes    | `object`          | pass directly to `<OnlineStatusNotification/>` as props |
 
 
 ### Next.js / Server Components

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nsn",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "private": false,
   "description": "React hook and notification component for detecting online/offline network status. Zero dependencies, SSR-safe, accessible.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nsn",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "private": false,
   "description": "React hook and notification component for detecting online/offline network status. Zero dependencies, SSR-safe, accessible.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nsn",
-  "version": "2.1.2",
+  "version": "2.2.0",
   "private": false,
   "description": "React hook and notification component for detecting online/offline network status. Zero dependencies, SSR-safe, accessible.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,11 @@
       "types": "./dist/react-nsn.d.ts",
       "import": "./dist/react-nsn.js",
       "require": "./dist/react-nsn.cjs"
+    },
+    "./headless": {
+      "types": "./dist/headless.d.ts",
+      "import": "./dist/headless.js",
+      "require": "./dist/headless.cjs"
     }
   },
   "lint-staged": {

--- a/src/App.css
+++ b/src/App.css
@@ -139,6 +139,7 @@
   cursor: pointer;
   border-radius: 50%;
   padding: 6px;
+  transition: background-color 150ms ease;
 }
 
 .statusNotification > .statusNotificationCloseIcon.defaultColor {
@@ -214,6 +215,18 @@
 .topLeft.fade-exit-active,
 .topRight.fade-exit-active {
   transform: translateY(-20px);
+}
+
+/* Reduced motion: disable slide/fade transitions */
+@media (prefers-reduced-motion: reduce) {
+  .fade-enter-active,
+  .fade-exit-active,
+  .topCenter.fade-enter-active,
+  .topCenter.fade-exit-active,
+  .bottomCenter.fade-enter-active,
+  .bottomCenter.fade-exit-active {
+    transition: none;
+  }
 }
 
 /* Mobile: full width at bottom */

--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -26,7 +26,13 @@ export type EventsCallback = {
   onCloseClick?: () => void
 }
 
+export interface OnlineStatusNotificationRef {
+  openStatus: () => void
+  dismiss: () => void
+}
+
 export interface OnlineStatusNotificationProps {
+  className?: string
   darkMode?: boolean
   destroyOnClose?: boolean
   /** @deprecated Use `destroyOnClose` instead */
@@ -36,6 +42,7 @@ export interface OnlineStatusNotificationProps {
   isOnline: boolean
   position?: Position
   statusText?: StatusText
+  style?: React.CSSProperties
 }
 
 type Phase = 'hidden' | 'entering' | 'visible' | 'exiting'
@@ -56,22 +63,25 @@ const TRANSITION_FALLBACK_MS = 400
  * }
  *
  * ```
+ * @param className additional CSS class name(s) to apply to the notification container
  * @param darkMode toggle dark mode on
  * @param destroyOnClose remove notification from dom when it hides
  * @param destoryOnClose @deprecated use `destroyOnClose` instead
  * @param duration duration of the notification in ms
- * @param eventsCallback object that contains 2 callbacks that are called when refresh button is clicked or close button clicked
+ * @param eventsCallback object that contains callbacks for refresh and close button clicks
  * @param isOnline status of the app when online
  * @param position customize notification component position
- * @param statusText customize online/offline status objects.
+ * @param statusText customize online/offline status objects
+ * @param style inline styles to apply to the notification container
  * @returns JSX Element
  *
  */
 const OnlineStatusNotificationComponent = forwardRef<
-  HTMLDivElement,
+  OnlineStatusNotificationRef,
   OnlineStatusNotificationProps
 >((props, ref) => {
   const {
+    className: userClassName,
     darkMode = false,
     destroyOnClose,
     destoryOnClose,
@@ -80,6 +90,7 @@ const OnlineStatusNotificationComponent = forwardRef<
     isOnline,
     position = 'bottomLeft',
     statusText,
+    style,
   } = props
 
   const shouldDestroyOnClose = destroyOnClose ?? destoryOnClose ?? true
@@ -105,7 +116,7 @@ const OnlineStatusNotificationComponent = forwardRef<
     })
   }, [])
 
-  React.useImperativeHandle(ref, (): any => ({
+  React.useImperativeHandle(ref, () => ({
     openStatus: () => enterNotification(isOnline),
     dismiss: () => setPhase('exiting'),
   }))
@@ -164,8 +175,8 @@ const OnlineStatusNotificationComponent = forwardRef<
   const handleRefreshButtonClick = () => {
     if (eventsCallback?.onRefreshClick) {
       eventsCallback.onRefreshClick()
-    } else {
-      location.reload()
+    } else if (typeof window !== 'undefined') {
+      window.location.reload()
     }
   }
 
@@ -198,7 +209,9 @@ const OnlineStatusNotificationComponent = forwardRef<
         darkMode ? 'darkColor' : 'defaultColor',
         position,
         phaseClass,
+        userClassName ?? '',
       )}
+      style={style}
       onTransitionEnd={handleTransitionEnd}
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}

--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -8,12 +8,12 @@ import React, {
 import './App.css'
 import { closeIcon, offlineIcon, onlineIcon } from './icons'
 
-type StatusText = {
+export type StatusText = {
   online?: string
   offline?: string
 }
 
-type Position =
+export type Position =
   | 'topLeft'
   | 'topRight'
   | 'topCenter'
@@ -26,8 +26,10 @@ type EventsCallback = {
   onCloseClick: () => void
 }
 
-interface OnlineStatusNotificationProps {
+export interface OnlineStatusNotificationProps {
   darkMode?: boolean
+  destroyOnClose?: boolean
+  /** @deprecated Use `destroyOnClose` instead */
   destoryOnClose?: boolean
   duration?: number
   eventsCallback?: EventsCallback
@@ -55,7 +57,8 @@ const TRANSITION_FALLBACK_MS = 400
  *
  * ```
  * @param darkMode toggle dark mode on
- * @param destoryOnClose remove notification from dom when it hides
+ * @param destroyOnClose remove notification from dom when it hides
+ * @param destoryOnClose @deprecated use `destroyOnClose` instead
  * @param duration duration of the notification in ms
  * @param eventsCallback object that contains 2 callbacks that are called when refresh button is clicked or close button clicked
  * @param isOnline status of the app when online
@@ -70,13 +73,16 @@ const OnlineStatusNotificationComponent = forwardRef<
 >((props, ref) => {
   const {
     darkMode = false,
-    destoryOnClose = true,
+    destroyOnClose,
+    destoryOnClose,
     duration = 4500,
     eventsCallback,
     isOnline,
     position = 'bottomLeft',
     statusText,
   } = props
+
+  const shouldDestroyOnClose = destroyOnClose ?? destoryOnClose ?? true
 
   const [phase, setPhase] = useState<Phase>('hidden')
   const [hovering, setHovering] = useState(false)
@@ -173,7 +179,7 @@ const OnlineStatusNotificationComponent = forwardRef<
     setPhase('exiting')
   }
 
-  if (destoryOnClose && phase === 'hidden') return null
+  if (shouldDestroyOnClose && phase === 'hidden') return null
 
   const phaseClass =
     phase === 'entering'

--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -50,6 +50,7 @@ type Phase = 'hidden' | 'entering' | 'visible' | 'exiting'
 const DefaultOnlineText = 'Your internet connection was restored.'
 const DefaultOfflineText = 'You are currently offline.'
 const TRANSITION_FALLBACK_MS = 400
+const SWIPE_THRESHOLD = 80
 
 /**
  * The notification component will pop up when the network status becomes offline and will popup once again when it goes back online
@@ -104,6 +105,14 @@ const OnlineStatusNotificationComponent = forwardRef<
   const isFirstChangeRef = useRef(true)
   const phaseRef = useRef<Phase>(phase)
   phaseRef.current = phase
+
+  // Swipe-to-dismiss tracking (ref-based to avoid re-renders during touchmove)
+  const nodeRef = useRef<HTMLDivElement>(null)
+  const touchActiveRef = useRef(false)
+  const touchStartXRef = useRef(0)
+  const touchStartYRef = useRef(0)
+  const swipeOffsetRef = useRef(0)
+  const baseTransformRef = useRef('')
 
   const isVisible = phase === 'visible'
 
@@ -191,6 +200,81 @@ const OnlineStatusNotificationComponent = forwardRef<
     setPhase('exiting')
   }
 
+  const handleTouchStart = (e: React.TouchEvent) => {
+    touchActiveRef.current = true
+    touchStartXRef.current = e.touches[0].clientX
+    touchStartYRef.current = e.touches[0].clientY
+    swipeOffsetRef.current = 0
+    const el = nodeRef.current
+    if (el) {
+      baseTransformRef.current = window.getComputedStyle(el).transform
+    }
+  }
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    const dx = e.touches[0].clientX - touchStartXRef.current
+    const dy = e.touches[0].clientY - touchStartYRef.current
+    // Only track horizontal swipes (ignore vertical scrolling)
+    if (Math.abs(dx) > Math.abs(dy)) {
+      swipeOffsetRef.current = dx
+      const el = nodeRef.current
+      if (el) {
+        const base =
+          baseTransformRef.current !== 'none'
+            ? `${baseTransformRef.current} `
+            : ''
+        el.style.transform = `${base}translateX(${dx}px)`
+        el.style.opacity = `${Math.max(0, 1 - Math.abs(dx) / (SWIPE_THRESHOLD * 2))}`
+        el.style.transition = 'none'
+      }
+    }
+  }
+
+  const handleTouchEnd = () => {
+    touchActiveRef.current = false
+    const offset = swipeOffsetRef.current
+    const el = nodeRef.current
+    swipeOffsetRef.current = 0
+
+    if (Math.abs(offset) >= SWIPE_THRESHOLD) {
+      // Animate off-screen in swipe direction, then dismiss
+      if (el) {
+        const base =
+          baseTransformRef.current !== 'none'
+            ? `${baseTransformRef.current} `
+            : ''
+        const direction = offset > 0 ? '100vw' : '-100vw'
+        el.style.transition = 'transform 200ms ease-out, opacity 200ms ease-out'
+        el.style.transform = `${base}translateX(${direction})`
+        el.style.opacity = '0'
+      }
+      setTimeout(() => {
+        if (el) {
+          el.style.transform = ''
+          el.style.opacity = ''
+          el.style.transition = ''
+        }
+        if (pendingOnlineRef.current !== null) {
+          enterNotification(pendingOnlineRef.current)
+        } else {
+          setPhase('hidden')
+        }
+      }, 200)
+    } else if (el) {
+      // Snap back smoothly
+      el.style.transition = 'transform 150ms ease, opacity 150ms ease'
+      requestAnimationFrame(() => {
+        if (el) {
+          el.style.transform = ''
+          el.style.opacity = ''
+        }
+        setTimeout(() => {
+          if (el) el.style.transition = ''
+        }, 150)
+      })
+    }
+  }
+
   if (shouldDestroyOnClose && phase === 'hidden') return null
 
   const phaseClass =
@@ -202,6 +286,7 @@ const OnlineStatusNotificationComponent = forwardRef<
 
   return (
     <div
+      ref={nodeRef}
       role="status"
       aria-live="polite"
       className={classNames(
@@ -213,8 +298,13 @@ const OnlineStatusNotificationComponent = forwardRef<
       )}
       style={style}
       onTransitionEnd={handleTransitionEnd}
-      onMouseEnter={() => setHovering(true)}
-      onMouseLeave={() => setHovering(false)}
+      onPointerEnter={() => setHovering(true)}
+      onPointerLeave={() => {
+        if (!touchActiveRef.current) setHovering(false)
+      }}
+      onTouchStart={handleTouchStart}
+      onTouchMove={handleTouchMove}
+      onTouchEnd={handleTouchEnd}
     >
       <div className="statusNotificationIcon">
         {displayedOnline ? onlineIcon : offlineIcon}

--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -21,9 +21,9 @@ export type Position =
   | 'bottomRight'
   | 'bottomCenter'
 
-type EventsCallback = {
-  onRefreshClick: () => void
-  onCloseClick: () => void
+export type EventsCallback = {
+  onRefreshClick?: () => void
+  onCloseClick?: () => void
 }
 
 export interface OnlineStatusNotificationProps {
@@ -107,6 +107,7 @@ const OnlineStatusNotificationComponent = forwardRef<
 
   React.useImperativeHandle(ref, (): any => ({
     openStatus: () => enterNotification(isOnline),
+    dismiss: () => setPhase('exiting'),
   }))
 
   // When isOnline changes, trigger the notification

--- a/src/__tests__/OnlineStatusNotification.test.tsx
+++ b/src/__tests__/OnlineStatusNotification.test.tsx
@@ -5,18 +5,14 @@ import OnlineStatusNotification from '../OnlineStatusNotification'
 describe('OnlineStatusNotification', () => {
   describe('rendering', () => {
     it('renders nothing on first render when online', () => {
-      const { container } = render(
-        <OnlineStatusNotification isOnline={true} />,
-      )
+      const { container } = render(<OnlineStatusNotification isOnline={true} />)
       expect(container.firstChild).toBeNull()
     })
 
     it('renders the notification immediately when starting offline', () => {
       render(<OnlineStatusNotification isOnline={false} />)
       expect(screen.getByRole('status')).toBeInTheDocument()
-      expect(
-        screen.getByText('You are currently offline.'),
-      ).toBeInTheDocument()
+      expect(screen.getByText('You are currently offline.')).toBeInTheDocument()
     })
 
     it('displays custom status text', () => {
@@ -30,14 +26,10 @@ describe('OnlineStatusNotification', () => {
     })
 
     it('shows notification when going offline after starting online', () => {
-      const { rerender } = render(
-        <OnlineStatusNotification isOnline={true} />,
-      )
+      const { rerender } = render(<OnlineStatusNotification isOnline={true} />)
       rerender(<OnlineStatusNotification isOnline={false} />)
       expect(screen.getByRole('status')).toBeInTheDocument()
-      expect(
-        screen.getByText('You are currently offline.'),
-      ).toBeInTheDocument()
+      expect(screen.getByText('You are currently offline.')).toBeInTheDocument()
     })
   })
 
@@ -93,31 +85,32 @@ describe('OnlineStatusNotification', () => {
 
   describe('dark mode', () => {
     it('applies darkColor class when darkMode is true', () => {
-      render(
-        <OnlineStatusNotification isOnline={false} darkMode={true} />,
-      )
+      render(<OnlineStatusNotification isOnline={false} darkMode={true} />)
       expect(screen.getByRole('status')).toHaveClass('darkColor')
     })
 
     it('applies defaultColor class when darkMode is false', () => {
-      render(
-        <OnlineStatusNotification isOnline={false} darkMode={false} />,
-      )
+      render(<OnlineStatusNotification isOnline={false} darkMode={false} />)
       expect(screen.getByRole('status')).toHaveClass('defaultColor')
     })
   })
 
   describe('position', () => {
     it('applies the specified position class', () => {
-      render(
-        <OnlineStatusNotification isOnline={false} position="topRight" />,
-      )
+      render(<OnlineStatusNotification isOnline={false} position="topRight" />)
       expect(screen.getByRole('status')).toHaveClass('topRight')
     })
   })
 
   describe('destroyOnClose', () => {
-    it('renders notification in DOM when destoryOnClose is true and visible', () => {
+    it('renders notification in DOM when destroyOnClose is true and visible', () => {
+      const { container } = render(
+        <OnlineStatusNotification isOnline={false} destroyOnClose={true} />,
+      )
+      expect(container.querySelector('.statusNotification')).toBeTruthy()
+    })
+
+    it('still supports the deprecated destoryOnClose prop', () => {
       const { container } = render(
         <OnlineStatusNotification isOnline={false} destoryOnClose={true} />,
       )

--- a/src/__tests__/OnlineStatusNotification.test.tsx
+++ b/src/__tests__/OnlineStatusNotification.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
 import { describe, expect, it, vi } from 'vitest'
-import OnlineStatusNotification from '../OnlineStatusNotification'
 import type { OnlineStatusNotificationRef } from '../OnlineStatusNotification'
+import OnlineStatusNotification from '../OnlineStatusNotification'
 
 describe('OnlineStatusNotification', () => {
   describe('rendering', () => {
@@ -164,6 +164,62 @@ describe('OnlineStatusNotification', () => {
         />,
       )
       expect(screen.getByRole('status')).toHaveStyle({ marginTop: '20px' })
+    })
+  })
+
+  describe('touch interactions', () => {
+    it('pauses auto-hide on pointerEnter and resumes on pointerLeave', () => {
+      vi.useFakeTimers()
+      render(<OnlineStatusNotification isOnline={false} duration={1000} />)
+      const el = screen.getByRole('status')
+
+      // Wait for entering → visible transition
+      act(() => {
+        vi.advanceTimersByTime(0)
+      })
+
+      fireEvent.pointerEnter(el)
+
+      // Advance past the duration — should NOT dismiss because pointer is active
+      act(() => {
+        vi.advanceTimersByTime(1500)
+      })
+      expect(screen.getByRole('status')).toBeInTheDocument()
+      expect(screen.getByRole('status')).not.toHaveClass('fade-exit-active')
+
+      fireEvent.pointerLeave(el)
+      vi.useRealTimers()
+    })
+
+    it('dismisses on horizontal swipe past threshold', () => {
+      vi.useFakeTimers()
+      const { container } = render(
+        <OnlineStatusNotification isOnline={false} />,
+      )
+      const el = screen.getByRole('status')
+
+      fireEvent.touchStart(el, { touches: [{ clientX: 100, clientY: 100 }] })
+      fireEvent.touchMove(el, { touches: [{ clientX: 200, clientY: 100 }] })
+      fireEvent.touchEnd(el)
+
+      // Wait for swipe-off animation to complete
+      act(() => {
+        vi.advanceTimersByTime(200)
+      })
+
+      expect(container.querySelector('.statusNotification')).toBeNull()
+      vi.useRealTimers()
+    })
+
+    it('does not dismiss on small swipe', () => {
+      render(<OnlineStatusNotification isOnline={false} />)
+      const el = screen.getByRole('status')
+
+      fireEvent.touchStart(el, { touches: [{ clientX: 100, clientY: 100 }] })
+      fireEvent.touchMove(el, { touches: [{ clientX: 130, clientY: 100 }] })
+      fireEvent.touchEnd(el)
+
+      expect(screen.getByRole('status')).not.toHaveClass('fade-exit-active')
     })
   })
 })

--- a/src/__tests__/OnlineStatusNotification.test.tsx
+++ b/src/__tests__/OnlineStatusNotification.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import OnlineStatusNotification from '../OnlineStatusNotification'
+import type { OnlineStatusNotificationRef } from '../OnlineStatusNotification'
 
 describe('OnlineStatusNotification', () => {
   describe('rendering', () => {
@@ -99,13 +100,13 @@ describe('OnlineStatusNotification', () => {
 
   describe('imperative handle', () => {
     it('dismiss() triggers the exiting phase', () => {
-      const ref = React.createRef<any>()
+      const ref = React.createRef<OnlineStatusNotificationRef>()
       render(<OnlineStatusNotification ref={ref} isOnline={false} />)
 
       expect(screen.getByRole('status')).toBeInTheDocument()
 
       act(() => {
-        ref.current.dismiss()
+        ref.current!.dismiss()
       })
 
       expect(screen.getByRole('status')).toHaveClass('fade-exit-active')
@@ -144,6 +145,25 @@ describe('OnlineStatusNotification', () => {
         <OnlineStatusNotification isOnline={false} destoryOnClose={true} />,
       )
       expect(container.querySelector('.statusNotification')).toBeTruthy()
+    })
+  })
+
+  describe('className and style', () => {
+    it('applies custom className to the notification', () => {
+      render(
+        <OnlineStatusNotification isOnline={false} className="my-custom" />,
+      )
+      expect(screen.getByRole('status')).toHaveClass('my-custom')
+    })
+
+    it('applies inline style to the notification', () => {
+      render(
+        <OnlineStatusNotification
+          isOnline={false}
+          style={{ marginTop: '20px' }}
+        />,
+      )
+      expect(screen.getByRole('status')).toHaveStyle({ marginTop: '20px' })
     })
   })
 })

--- a/src/__tests__/OnlineStatusNotification.test.tsx
+++ b/src/__tests__/OnlineStatusNotification.test.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import OnlineStatusNotification from '../OnlineStatusNotification'
 
@@ -56,12 +57,25 @@ describe('OnlineStatusNotification', () => {
   })
 
   describe('click handlers', () => {
+    it('works with only onCloseClick in eventsCallback', () => {
+      const onCloseClick = vi.fn()
+      render(
+        <OnlineStatusNotification
+          isOnline={false}
+          eventsCallback={{ onCloseClick }}
+        />,
+      )
+
+      fireEvent.click(screen.getByLabelText('Close notification'))
+      expect(onCloseClick).toHaveBeenCalledTimes(1)
+    })
+
     it('calls onRefreshClick callback when refresh is clicked', () => {
       const onRefreshClick = vi.fn()
       render(
         <OnlineStatusNotification
           isOnline={false}
-          eventsCallback={{ onRefreshClick, onCloseClick: vi.fn() }}
+          eventsCallback={{ onRefreshClick }}
         />,
       )
 
@@ -74,12 +88,27 @@ describe('OnlineStatusNotification', () => {
       render(
         <OnlineStatusNotification
           isOnline={false}
-          eventsCallback={{ onRefreshClick: vi.fn(), onCloseClick }}
+          eventsCallback={{ onCloseClick }}
         />,
       )
 
       fireEvent.click(screen.getByLabelText('Close notification'))
       expect(onCloseClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('imperative handle', () => {
+    it('dismiss() triggers the exiting phase', () => {
+      const ref = React.createRef<any>()
+      render(<OnlineStatusNotification ref={ref} isOnline={false} />)
+
+      expect(screen.getByRole('status')).toBeInTheDocument()
+
+      act(() => {
+        ref.current.dismiss()
+      })
+
+      expect(screen.getByRole('status')).toHaveClass('fade-exit-active')
     })
   })
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -71,6 +71,16 @@ describe('useOnlineStatus', () => {
     expect(result.current.isOnline).toBe(true)
   })
 
+  it('checkNow triggers a fetch call', async () => {
+    const { result } = renderHook(() => useOnlineStatus())
+
+    await act(async () => {
+      await result.current.checkNow()
+    })
+
+    expect(globalThis.fetch).toHaveBeenCalled()
+  })
+
   it('polls at the specified duration', async () => {
     renderHook(() => useOnlineStatus({ pollingDuration: 5000 }))
 
@@ -82,9 +92,74 @@ describe('useOnlineStatus', () => {
     expect(globalThis.fetch).toHaveBeenCalled()
   })
 
-  it('error property is null by default', () => {
-    const { result } = renderHook(() => useOnlineStatus())
-    expect(result.current.error).toBeNull()
+  it('fires onStatusChange when going offline', async () => {
+    const onStatusChange = vi.fn()
+    renderHook(() => useOnlineStatus({ onStatusChange }))
+
+    await act(async () => {
+      window.dispatchEvent(new Event('offline'))
+    })
+
+    expect(onStatusChange).toHaveBeenCalledWith(false)
+  })
+
+  it('fires onStatusChange when coming back online', async () => {
+    const onStatusChange = vi.fn()
+    renderHook(() => useOnlineStatus({ onStatusChange }))
+
+    // Go offline first
+    await act(async () => {
+      window.dispatchEvent(new Event('offline'))
+    })
+
+    onStatusChange.mockClear()
+
+    // Come back online
+    await act(async () => {
+      window.dispatchEvent(new Event('online'))
+    })
+
+    expect(onStatusChange).toHaveBeenCalledWith(true)
+  })
+
+  it('pauses polling when the tab is hidden', async () => {
+    renderHook(() => useOnlineStatus({ pollingDuration: 5000 }))
+
+    // Clear any initial fetch calls
+    vi.mocked(globalThis.fetch).mockClear()
+
+    // Hide the tab
+    Object.defineProperty(document, 'hidden', {
+      value: true,
+      writable: true,
+      configurable: true,
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(10000)
+    })
+
+    // No polling should have occurred while hidden
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+
+    // Show the tab again
+    Object.defineProperty(document, 'hidden', {
+      value: false,
+      configurable: true,
+    })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    // Polling should resume
+    expect(globalThis.fetch).toHaveBeenCalled()
   })
 })
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -122,6 +122,59 @@ describe('useOnlineStatus', () => {
     expect(onStatusChange).toHaveBeenCalledWith(true)
   })
 
+  it('uses custom pollingFn when provided', async () => {
+    const pollingFn = vi.fn().mockResolvedValue(true)
+    renderHook(() => useOnlineStatus({ pollingFn, pollingDuration: 5000 }))
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(pollingFn).toHaveBeenCalled()
+    // Should NOT use fetch when pollingFn is provided
+    expect(globalThis.fetch).not.toHaveBeenCalled()
+  })
+
+  it('detects offline status via custom pollingFn returning false', async () => {
+    const pollingFn = vi.fn().mockResolvedValue(false)
+    const { result } = renderHook(() =>
+      useOnlineStatus({ pollingFn, pollingDuration: 5000 }),
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000)
+    })
+
+    expect(result.current.isOnline).toBe(false)
+  })
+
+  it('backs off polling interval when offline', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'))
+    renderHook(() => useOnlineStatus({ pollingDuration: 1000 }))
+
+    vi.mocked(globalThis.fetch).mockClear()
+
+    // First poll at 1s — should fire
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+
+    // After first failure, delay doubles to 2s
+    // At 2s mark (1s after last poll), should NOT have fired again
+    vi.mocked(globalThis.fetch).mockClear()
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(globalThis.fetch).toHaveBeenCalledTimes(0)
+
+    // At 2s after last poll, should fire
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
   it('pauses polling when the tab is hidden', async () => {
     renderHook(() => useOnlineStatus({ pollingDuration: 5000 }))
 

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -154,12 +154,15 @@ describe('useOnlineStatus', () => {
       document.dispatchEvent(new Event('visibilitychange'))
     })
 
+    // Should check immediately on tab return
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+
     await act(async () => {
       vi.advanceTimersByTime(5000)
     })
 
-    // Polling should resume
-    expect(globalThis.fetch).toHaveBeenCalled()
+    // And polling should resume after the interval
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
   })
 })
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -1,0 +1,2 @@
+export { useOnlineStatus } from './hooks'
+export type { NetworkInformation, OnlineStatusResult } from './hooks'

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useReducer, useRef } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
 import { DEFAULT_POLLING_URL, timeSince } from './utils'
 
 const isWindowDocumentAvailable = typeof window !== 'undefined'
@@ -20,6 +27,7 @@ function getConnectionInfo(): NetworkInformation | null {
 type OnlineStatusProps = {
   pollingUrl?: string
   pollingDuration?: number
+  onStatusChange?: (isOnline: boolean) => void
 }
 
 const InitialOnlineStatus = isNavigatorObjectAvailable ? navigator.onLine : true
@@ -71,22 +79,27 @@ function statusReducer(prevState: State, action: ReducerActions): State {
  * ```
  * @param pollingUrl your custom polling url
  * @param pollingDuration your custom polling duration in ms
+ * @param onStatusChange callback fired when the online status changes (skips initial render)
  * @returns Current network status, connection info,
- * and time since online/offline,
- * attributes to be passed to notification component if used
+ * time since online/offline,
+ * attributes to be passed to notification component if used,
+ * and checkNow to manually trigger a connectivity check
  */
+
+type OnlineStatusResult = {
+  attributes: { isOnline: boolean }
+  checkNow: () => Promise<void>
+  connectionInfo: NetworkInformation | null
+  isOffline: boolean
+  isOnline: boolean
+  time: { since: Date; difference: string }
+}
 
 function useOnlineStatus({
   pollingUrl = DEFAULT_POLLING_URL,
   pollingDuration = 12000,
-}: OnlineStatusProps = {}): {
-  attributes: { isOnline: boolean }
-  connectionInfo: NetworkInformation | null
-  error: Error | null
-  isOffline: boolean
-  isOnline: boolean
-  time: { since: Date; difference: string }
-} {
+  onStatusChange,
+}: OnlineStatusProps = {}): OnlineStatusResult {
   const [statusState, dispatch] = useReducer(statusReducer, {
     online: InitialOnlineStatus,
     time: {
@@ -95,7 +108,7 @@ function useOnlineStatus({
     },
   })
 
-  const connectionInfo = getConnectionInfo()
+  const connectionInfo = useMemo(() => getConnectionInfo(), [])
 
   const _onlineStatusFn = useCallback(async () => {
     await fetch(pollingUrl, { mode: 'no-cors' })
@@ -113,7 +126,20 @@ function useOnlineStatus({
       })
   }, [pollingUrl])
 
-  useInterval(_onlineStatusFn, pollingDuration)
+  const [tabVisible, setTabVisible] = useState(
+    isWindowDocumentAvailable ? !document.hidden : true,
+  )
+
+  useEffect(() => {
+    if (isWindowDocumentAvailable) {
+      const onVisibilityChange = () => setTabVisible(!document.hidden)
+      document.addEventListener('visibilitychange', onVisibilityChange)
+      return () =>
+        document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [])
+
+  useInterval(_onlineStatusFn, tabVisible ? pollingDuration : null)
 
   const handleOnlineStatus = useCallback(
     async ({ type }: Event) => {
@@ -139,10 +165,23 @@ function useOnlineStatus({
     }
   }, [handleOnlineStatus])
 
+  // Fire onStatusChange callback when status changes (skip initial render)
+  const onStatusChangeRef = useRef(onStatusChange)
+  onStatusChangeRef.current = onStatusChange
+  const isInitialRenderRef = useRef(true)
+
+  useEffect(() => {
+    if (isInitialRenderRef.current) {
+      isInitialRenderRef.current = false
+      return
+    }
+    onStatusChangeRef.current?.(statusState.online)
+  }, [statusState.online])
+
   return {
     attributes: { isOnline: statusState.online },
+    checkNow: _onlineStatusFn,
     connectionInfo,
-    error: null,
     isOffline: !statusState.online,
     isOnline: statusState.online,
     time: { since: statusState.time.since, difference: statusState.time.diff },
@@ -180,6 +219,7 @@ export function useInterval(
 }
 
 export { useOnlineStatus }
+export type { OnlineStatusResult }
 
 type Megabit = number
 type Millisecond = number
@@ -194,7 +234,7 @@ type ConnectionType =
   | 'unknown'
   | 'wifi'
   | 'wimax'
-interface NetworkInformation extends EventTarget {
+export interface NetworkInformation extends EventTarget {
   readonly type?: ConnectionType
   readonly effectiveType?: EffectiveConnectionType
   readonly downlinkMax?: Megabit

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -64,7 +64,7 @@ function statusReducer(prevState: State, action: ReducerActions): State {
       }
     }
     default:
-      return { ...prevState }
+      return prevState
   }
 }
 
@@ -111,19 +111,12 @@ function useOnlineStatus({
   const connectionInfo = useMemo(() => getConnectionInfo(), [])
 
   const _onlineStatusFn = useCallback(async () => {
-    await fetch(pollingUrl, { mode: 'no-cors' })
-      .then(
-        (response) =>
-          response &&
-          dispatch({
-            type: 'online',
-          }),
-      )
-      .catch(() => {
-        return dispatch({
-          type: 'offline',
-        })
-      })
+    try {
+      await fetch(pollingUrl, { mode: 'no-cors' })
+      dispatch({ type: 'online' })
+    } catch {
+      dispatch({ type: 'offline' })
+    }
   }, [pollingUrl])
 
   const [tabVisible, setTabVisible] = useState(
@@ -132,17 +125,21 @@ function useOnlineStatus({
 
   useEffect(() => {
     if (isWindowDocumentAvailable) {
-      const onVisibilityChange = () => setTabVisible(!document.hidden)
+      const onVisibilityChange = () => {
+        const visible = !document.hidden
+        setTabVisible(visible)
+        if (visible) _onlineStatusFn()
+      }
       document.addEventListener('visibilitychange', onVisibilityChange)
       return () =>
         document.removeEventListener('visibilitychange', onVisibilityChange)
     }
-  }, [])
+  }, [_onlineStatusFn])
 
   useInterval(_onlineStatusFn, tabVisible ? pollingDuration : null)
 
   const handleOnlineStatus = useCallback(
-    async ({ type }: Event) => {
+    ({ type }: Event) => {
       if (type === 'online') {
         _onlineStatusFn()
       } else {

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -27,6 +27,7 @@ function getConnectionInfo(): NetworkInformation | null {
 type OnlineStatusProps = {
   pollingUrl?: string
   pollingDuration?: number
+  pollingFn?: () => Promise<boolean>
   onStatusChange?: (isOnline: boolean) => void
 }
 
@@ -79,6 +80,7 @@ function statusReducer(prevState: State, action: ReducerActions): State {
  * ```
  * @param pollingUrl your custom polling url
  * @param pollingDuration your custom polling duration in ms
+ * @param pollingFn custom async function for connectivity checks — should return `true` if online, `false` if offline. Overrides `pollingUrl` when provided
  * @param onStatusChange callback fired when the online status changes (skips initial render)
  * @returns Current network status, connection info,
  * time since online/offline,
@@ -98,6 +100,7 @@ type OnlineStatusResult = {
 function useOnlineStatus({
   pollingUrl = DEFAULT_POLLING_URL,
   pollingDuration = 12000,
+  pollingFn,
   onStatusChange,
 }: OnlineStatusProps = {}): OnlineStatusResult {
   const [statusState, dispatch] = useReducer(statusReducer, {
@@ -110,14 +113,31 @@ function useOnlineStatus({
 
   const connectionInfo = useMemo(() => getConnectionInfo(), [])
 
+  const pollingFnRef = useRef(pollingFn)
+  pollingFnRef.current = pollingFn
+
+  const [effectiveDelay, setEffectiveDelay] = useState(pollingDuration)
+
   const _onlineStatusFn = useCallback(async () => {
     try {
-      await fetch(pollingUrl, { mode: 'no-cors' })
-      dispatch({ type: 'online' })
+      if (pollingFnRef.current) {
+        const online = await pollingFnRef.current()
+        dispatch({ type: online ? 'online' : 'offline' })
+        if (online) {
+          setEffectiveDelay(pollingDuration)
+        } else {
+          setEffectiveDelay((prev) => Math.min(prev * 2, 60000))
+        }
+      } else {
+        await fetch(pollingUrl, { mode: 'no-cors' })
+        dispatch({ type: 'online' })
+        setEffectiveDelay(pollingDuration)
+      }
     } catch {
       dispatch({ type: 'offline' })
+      setEffectiveDelay((prev) => Math.min(prev * 2, 60000))
     }
-  }, [pollingUrl])
+  }, [pollingUrl, pollingDuration])
 
   const [tabVisible, setTabVisible] = useState(
     isWindowDocumentAvailable ? !document.hidden : true,
@@ -136,7 +156,7 @@ function useOnlineStatus({
     }
   }, [_onlineStatusFn])
 
-  useInterval(_onlineStatusFn, tabVisible ? pollingDuration : null)
+  useInterval(_onlineStatusFn, tabVisible ? effectiveDelay : null)
 
   const handleOnlineStatus = useCallback(
     ({ type }: Event) => {

--- a/src/nsn.ts
+++ b/src/nsn.ts
@@ -2,7 +2,9 @@ export { useOnlineStatus } from './hooks'
 export type { NetworkInformation, OnlineStatusResult } from './hooks'
 export { default as OnlineStatusNotification } from './OnlineStatusNotification'
 export type {
+  EventsCallback,
   OnlineStatusNotificationProps,
+  OnlineStatusNotificationRef,
   Position,
   StatusText,
 } from './OnlineStatusNotification'

--- a/src/nsn.ts
+++ b/src/nsn.ts
@@ -1,2 +1,8 @@
 export { useOnlineStatus } from './hooks'
+export type { NetworkInformation, OnlineStatusResult } from './hooks'
 export { default as OnlineStatusNotification } from './OnlineStatusNotification'
+export type {
+  OnlineStatusNotificationProps,
+  Position,
+  StatusText,
+} from './OnlineStatusNotification'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,13 +16,16 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/**/*.{ts,tsx}'],
-      exclude: ['src/__tests__/**', 'src/nsn.ts', 'src/icons.tsx'],
+      exclude: ['src/__tests__/**', 'src/nsn.ts', 'src/headless.ts', 'src/icons.tsx'],
     },
   },
 
   plugins: [
     react(),
-    cssInjectedByJsPlugin(),
+    cssInjectedByJsPlugin({
+      jsAssetsFilterFunction: (outputChunk) =>
+        outputChunk.fileName.startsWith('react-nsn'),
+    }),
     dts({
       insertTypesEntry: true,
       rollupTypes: true,
@@ -38,9 +41,10 @@ export default defineConfig({
 
   build: {
     lib: {
-      entry: resolve(__dirname, 'src/nsn.ts'),
-      name: 'react-nsn',
-      fileName: 'react-nsn',
+      entry: {
+        'react-nsn': resolve(__dirname, 'src/nsn.ts'),
+        headless: resolve(__dirname, 'src/headless.ts'),
+      },
       formats: ['cjs', 'es'],
     },
     rollupOptions: {


### PR DESCRIPTION
## Summary
- Add `prefers-reduced-motion` support — disables slide/fade transitions for motion-sensitive users
- Smooth close icon hover via `background-color` transition (150ms ease)
- Unified pointer events (`pointerEnter`/`pointerLeave`) replace mouse-only hover, covering both desktop and touch pause
- Swipe-to-dismiss with ref-based DOM manipulation — composes transforms for centered positions, animates off-screen before cleanup, no visual snap-back
- Guard `pointerLeave` during active touch to prevent auto-dismiss timer restart mid-swipe
- Bump to v2.4.0

## Test plan
- [ ] Verify `prefers-reduced-motion: reduce` disables notification transitions
- [ ] Verify close icon background fades smoothly on hover
- [ ] Verify hovering (desktop) and tapping (mobile) pauses auto-hide timer
- [ ] Verify horizontal swipe past 80px threshold dismisses notification
- [ ] Verify small swipe snaps back smoothly
- [ ] Verify centered positions (`topCenter`, `bottomCenter`) don't jump during swipe
- [ ] All 46 tests pass, type-check, lint, build green