### PR TITLE
fix: targeted runtime/DX fixes and constant extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.5.0
+
+### Fixes
+
+- Fix example app reducer default `duration: 4.5` → `4500` (notification vanished instantly on state reset)
+- Fix swipe animation timing mismatch: extract hardcoded `200ms` to `SWIPE_ANIMATION_MS` constant shared between inline transition and setTimeout
+
+### Improvements
+
+- Deduplicate network check on tab resume: `useInterval` now fires immediately when delay transitions from `null` to a number, removing redundant `checkStatus()` call from visibility handler
+- Cache `getComputedStyle` for touch handling: capture base transform once on phase `'visible'` instead of on every `touchstart`
+- Add dev-mode deprecation warning when `destoryOnClose` prop is used
+
+### Internal
+
+- Extract all module-level constants into `src/constants.ts`
+- Add `useInterval` resume-fire test
+- Add `destoryOnClose` deprecation warning test
+
 ## 2.4.4
 
 ### Chores

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -70,7 +70,7 @@ function reducer(state: State, action: ReducerActions) {
       newState = {
         position: 'bottomLeft',
         darkMode: true,
-        duration: 4.5,
+        duration: 4500,
         statusText: {
           online: `Your internet connection was restored.`,
           offline: `You are currently offline.`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-nsn",
-  "version": "2.4.4",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-nsn",
-      "version": "2.4.4",
+      "version": "2.5.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nsn",
-  "version": "2.4.4",
+  "version": "2.5.0",
   "private": false,
   "description": "Detect online/offline status in React. Hook + notification component. Zero deps, SSR-safe, React 16-19.",
   "license": "MIT",

--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -5,6 +5,13 @@ import React, {
   useRef,
   useState,
 } from 'react'
+import {
+  DEFAULT_OFFLINE_TEXT,
+  DEFAULT_ONLINE_TEXT,
+  SWIPE_ANIMATION_MS,
+  SWIPE_THRESHOLD,
+  TRANSITION_FALLBACK_MS,
+} from './constants'
 import { closeIcon, offlineIcon, onlineIcon } from './icons'
 import './notification.css'
 
@@ -47,10 +54,8 @@ export interface OnlineStatusNotificationProps {
 
 type Phase = 'hidden' | 'entering' | 'visible' | 'exiting'
 
-const DEFAULT_ONLINE_TEXT = 'Your internet connection was restored.'
-const DEFAULT_OFFLINE_TEXT = 'You are currently offline.'
-const TRANSITION_FALLBACK_MS = 400
-const SWIPE_THRESHOLD = 80
+
+let hasWarnedDestoryOnClose = false
 
 /**
  * The notification component will pop up when the network status becomes offline and will popup once again when it goes back online
@@ -94,6 +99,15 @@ const OnlineStatusNotificationComponent = forwardRef<
     style,
   } = props
 
+  if (!hasWarnedDestoryOnClose && destoryOnClose !== undefined) {
+    if (process.env.NODE_ENV !== 'production') {
+      hasWarnedDestoryOnClose = true
+      console.warn(
+        'react-nsn: `destoryOnClose` is deprecated and will be removed in a future release. Use `destroyOnClose` instead.',
+      )
+    }
+  }
+
   const shouldDestroyOnClose = destroyOnClose ?? destoryOnClose ?? true
 
   const [phase, setPhase] = useState<Phase>('hidden')
@@ -115,6 +129,13 @@ const OnlineStatusNotificationComponent = forwardRef<
   const baseTransformRef = useRef('')
 
   const isVisible = phase === 'visible'
+
+  useEffect(() => {
+    if (phase === 'visible' && nodeRef.current) {
+      baseTransformRef.current =
+        window.getComputedStyle(nodeRef.current).transform
+    }
+  }, [phase])
 
   const enterNotification = useCallback((online: boolean) => {
     setDisplayedOnline(online)
@@ -205,10 +226,6 @@ const OnlineStatusNotificationComponent = forwardRef<
     touchStartXRef.current = e.touches[0].clientX
     touchStartYRef.current = e.touches[0].clientY
     swipeOffsetRef.current = 0
-    const el = nodeRef.current
-    if (el) {
-      baseTransformRef.current = window.getComputedStyle(el).transform
-    }
   }
 
   const handleTouchMove = (e: React.TouchEvent) => {
@@ -244,7 +261,7 @@ const OnlineStatusNotificationComponent = forwardRef<
             ? `${baseTransformRef.current} `
             : ''
         const direction = offset > 0 ? '100vw' : '-100vw'
-        el.style.transition = 'transform 200ms ease-out, opacity 200ms ease-out'
+        el.style.transition = `transform ${SWIPE_ANIMATION_MS}ms ease-out, opacity ${SWIPE_ANIMATION_MS}ms ease-out`
         el.style.transform = `${base}translateX(${direction})`
         el.style.opacity = '0'
       }
@@ -259,7 +276,7 @@ const OnlineStatusNotificationComponent = forwardRef<
         } else {
           setPhase('hidden')
         }
-      }, 200)
+      }, SWIPE_ANIMATION_MS)
     } else if (el) {
       // Snap back smoothly
       el.style.transition = 'transform 150ms ease, opacity 150ms ease'

--- a/src/OnlineStatusNotification.tsx
+++ b/src/OnlineStatusNotification.tsx
@@ -54,7 +54,6 @@ export interface OnlineStatusNotificationProps {
 
 type Phase = 'hidden' | 'entering' | 'visible' | 'exiting'
 
-
 let hasWarnedDestoryOnClose = false
 
 /**
@@ -132,8 +131,9 @@ const OnlineStatusNotificationComponent = forwardRef<
 
   useEffect(() => {
     if (phase === 'visible' && nodeRef.current) {
-      baseTransformRef.current =
-        window.getComputedStyle(nodeRef.current).transform
+      baseTransformRef.current = window.getComputedStyle(
+        nodeRef.current,
+      ).transform
     }
   }, [phase])
 

--- a/src/__tests__/OnlineStatusNotification.test.tsx
+++ b/src/__tests__/OnlineStatusNotification.test.tsx
@@ -132,6 +132,22 @@ describe('OnlineStatusNotification', () => {
     })
   })
 
+  describe('deprecation warning', () => {
+    it('warns in dev mode when destoryOnClose is used', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      render(
+        <OnlineStatusNotification isOnline={false} destoryOnClose={true} />,
+      )
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('`destoryOnClose` is deprecated'),
+      )
+
+      warnSpy.mockRestore()
+    })
+  })
+
   describe('destroyOnClose', () => {
     it('renders notification in DOM when destroyOnClose is true and visible', () => {
       const { container } = render(

--- a/src/__tests__/hooks.test.ts
+++ b/src/__tests__/hooks.test.ts
@@ -252,6 +252,31 @@ describe('useInterval', () => {
     expect(callback).not.toHaveBeenCalled()
   })
 
+  it('fires immediately when delay transitions from null to a number', async () => {
+    const callback = vi.fn().mockResolvedValue(undefined)
+
+    const { rerender } = renderHook(
+      ({ delay }) => useInterval(callback, delay),
+      { initialProps: { delay: null as number | null } },
+    )
+
+    // Should not have been called while paused
+    expect(callback).not.toHaveBeenCalled()
+
+    // Resume with a delay
+    rerender({ delay: 1000 })
+
+    // Should fire immediately on resume
+    expect(callback).toHaveBeenCalledTimes(1)
+
+    // And continue at the interval
+    await act(async () => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(callback).toHaveBeenCalledTimes(2)
+  })
+
   it('cleans up interval on unmount', async () => {
     const callback = vi.fn().mockResolvedValue(undefined)
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_POLLING_URL = 'https://www.gstatic.com/generate_204'
+
+export const DEFAULT_ONLINE_TEXT = 'Your internet connection was restored.'
+export const DEFAULT_OFFLINE_TEXT = 'You are currently offline.'
+
+export const TRANSITION_FALLBACK_MS = 400
+export const SWIPE_ANIMATION_MS = 200
+export const SWIPE_THRESHOLD = 80

--- a/src/hooks.tsx
+++ b/src/hooks.tsx
@@ -6,7 +6,8 @@ import {
   useRef,
   useState,
 } from 'react'
-import { DEFAULT_POLLING_URL, timeSince } from './utils'
+import { DEFAULT_POLLING_URL } from './constants'
+import { timeSince } from './utils'
 
 const isBrowser = typeof window !== 'undefined'
 
@@ -146,15 +147,13 @@ export function useOnlineStatus({
   useEffect(() => {
     if (isBrowser) {
       const onVisibilityChange = () => {
-        const visible = !document.hidden
-        setTabVisible(visible)
-        if (visible) checkStatus()
+        setTabVisible(!document.hidden)
       }
       document.addEventListener('visibilitychange', onVisibilityChange)
       return () =>
         document.removeEventListener('visibilitychange', onVisibilityChange)
     }
-  }, [checkStatus])
+  }, [])
 
   useInterval(checkStatus, tabVisible ? effectiveDelay : null)
 
@@ -218,17 +217,22 @@ export function useInterval(
   delay: number | null,
 ) {
   const savedCallback = useRef<(() => Promise<void>) | null>(null)
+  const prevDelayRef = useRef<number | null>(delay)
 
   useEffect(() => {
     savedCallback.current = callback
   }, [callback])
 
   useEffect(() => {
+    const wasNull = prevDelayRef.current === null
+    prevDelayRef.current = delay
+
     function tick() {
       savedCallback.current?.()
     }
 
     if (delay !== null) {
+      if (wasNull) tick()
       const id = setInterval(tick, delay)
       return () => clearInterval(id)
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,5 +18,3 @@ export function timeSince(date: Date) {
 
   return `${seconds} second${seconds === 1 ? '' : 's'}`
 }
-
-export const DEFAULT_POLLING_URL = 'https://www.gstatic.com/generate_204'


### PR DESCRIPTION
this PR fixes 2 bugs (example app duration mismatch, swipe animation timing desync), adds 3 DX improvements (deduplicate tab-resume polling via useInterval immediate-fire, cache getComputedStyle for touch handling, dev-mode deprecation warning for destoryOnClose), and extracts all module-level constants into src/constants.ts. bumps version to 2.5.0.