### PR TITLE
chore: add changelog entry and bump to 2.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.5.2
+
+### Fixes
+
+- Resolve high-severity minimatch ReDoS vulnerability in `@microsoft/api-extractor` via npm override (`^10.2.3`)
+- Fix example app React types mismatch (`@types/react` 18 → 19) that broke demo site build
+
 ## 2.5.1
 
 ### Chores

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-nsn",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-nsn",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-nsn",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "private": false,
   "description": "Detect online/offline status in React. Hook + notification component. Zero deps, SSR-safe, React 16-19.",
   "license": "MIT",


### PR DESCRIPTION
this PR adds a changelog entry for the minimatch vulnerability fix and example React types upgrade, and bumps the version to 2.5.2.